### PR TITLE
Remove unnecessary pytest cache

### DIFF
--- a/.cache/v/cache/lastfailed
+++ b/.cache/v/cache/lastfailed
@@ -1,8 +1,0 @@
-{
-  "eleanor/tests/test_targetdata.py": true,
-  "eleanor/tests/test_tpfs.py": true,
-  "eleanor/tests/testing.py": true,
-  "make_guide.py": true,
-  "testing.py": true,
-  "tests/test_tpfs.py": true
-}


### PR DESCRIPTION
Fixes #96: We don't need this cache directory.