### PR TITLE
directly use the ffiindex from the FFIs when available

### DIFF
--- a/make_postcards.py
+++ b/make_postcards.py
@@ -113,8 +113,12 @@ def make_postcards(fns, outdir, width=104, height=148, wstep=None, hstep=None):
     s = int(sector[1::])
     metadata_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                 'metadata', 's{0:04d}'.format(s))
-    ffiindex = np.loadtxt(os.path.join(metadata_dir,
-                                       'cadences_s{0:04d}.txt'.format(s)))
+    if f.ffiindex is None:
+        ffiindex = np.loadtxt(os.path.join(metadata_dir,
+                                           'cadences_s{0:04d}.txt'.format(s)))
+    else:
+        ffiindex = f.ffiindex * 1
+
     sc_fn = os.path.join(metadata_dir, 'target_s{0:04d}.fits'.format(s))
 
     # We'll have the same primary HDU for each postcard - this will store the
@@ -286,6 +290,9 @@ def run_sector_camera_chip(base_dir, output_dir, sector, camera, chip):
                            "*", "*",
                            "{0:d}-{1:d}".format(camera, chip),
                            "*.fits")
+    #fnpattern = f"tess*-s{sector:04d}-{camera:d}-" \
+    #    f"{chip:d}-*fits"
+    #pattern = os.path.join(base_dir, 'sector{0}'.format(sector), fnpattern)
 
     outdir = os.path.join(output_dir, "s{0:04d}".format(sector),
                           "{0:d}-{1:d}".format(camera, chip))

--- a/make_postcards.py
+++ b/make_postcards.py
@@ -290,9 +290,6 @@ def run_sector_camera_chip(base_dir, output_dir, sector, camera, chip):
                            "*", "*",
                            "{0:d}-{1:d}".format(camera, chip),
                            "*.fits")
-    #fnpattern = f"tess*-s{sector:04d}-{camera:d}-" \
-    #    f"{chip:d}-*fits"
-    #pattern = os.path.join(base_dir, 'sector{0}'.format(sector), fnpattern)
 
     outdir = os.path.join(output_dir, "s{0:04d}".format(sector),
                           "{0:d}-{1:d}".format(camera, chip))


### PR DESCRIPTION
When making postcards, this directly pulls the ffiindex from the FFIs if they're available, and reverts to the manual lists for the early sectors when this wasn't available.

Note: was easier to make a new branch and resubmit the PR than muck around with the old PR.