### PR TITLE
imports updated to work with lightkurve 1.1

### DIFF
--- a/eleanor/crossmatch.py
+++ b/eleanor/crossmatch.py
@@ -5,7 +5,7 @@ import socket
 import pandas as pd
 from astroquery.mast import Observations
 from astropy.io import fits
-from lightkurve import search_targetpixelfile
+from lightkurve.search import search_targetpixelfile
 
 from .utils import *
 


### PR DESCRIPTION
Hey Adina! I'm working with a clone of the eleanor repo, downloaded today (8/22). I wasn't able to import the search_targetpixelfile function from lightkurve without adding lightkurve.search. I'm not sure if it's a lightkurve update or if I'm using a different lightkurve version, but I thought I would add it here in case anyone needs this too.