### PR TITLE
Updates to allow people to run a full pipeline of eleanor locally

### DIFF
--- a/convolve_cbvs.py
+++ b/convolve_cbvs.py
@@ -1,0 +1,46 @@
+import os
+import sys
+from glob import glob
+
+import numpy as np
+from astropy.io import fits
+from tqdm import trange
+
+sectors = [int(sys.argv[1])]
+# get times from the postcards
+postdir = sys.argv[2]
+
+for sector in sectors:
+    cbv_dir = './cbvs/'
+    files = glob(os.path.join(cbv_dir, f'*s{sector:04d}*cbv.fits'))
+
+    for c in trange(len(files)):
+        cbv = fits.open(files[c])
+        camera = cbv[1].header['CAMERA']
+        ccd = cbv[1].header['CCD']
+        cbv_time = cbv[1].data['Time']
+
+        postfile = os.path.join(postdir, f'{camera}-{ccd}')
+        if not os.path.exists(postfile):
+            print(f'dir {postfile} does not exist; skipping')
+            continue
+
+        postfile = glob(os.path.join(postfile, '*[0-9]_pc.fits'))[0]
+        hdu = fits.open(postfile)
+        tstart = hdu[1].data['tstart']
+        tend = hdu[1].data['tstop']
+
+        new_fn = './metadata/s{0:04d}/cbv_components_s{0:04d}_{1:04d}_{2:04d}.txt'.format(
+            sector, camera, ccd)
+
+        convolved = np.zeros((len(tstart), 16))
+        inds = np.array([], dtype=int)
+        for i in range(len(tstart)):
+            g = np.where((cbv_time >= tstart[i]) & (cbv_time <= tend[i]))[0]
+            assert len(g) == 15
+            for j in range(16):
+                index = 'VECTOR_{0}'.format(j + 1)
+                convolved[i, j] = np.mean(cbv[1].data[index][g])
+        np.savetxt(new_fn, convolved)
+        cbv.close()
+        hdu.close()

--- a/eleanor/ffi.py
+++ b/eleanor/ffi.py
@@ -15,24 +15,32 @@ import urllib
 from .mast import tic_by_contamination
 
 
-def load_pointing_model(sector, camera, chip):
+def load_pointing_model(sector, camera, chip, localdir=None):
     """ Loads in pointing model from website.
     """
-    user_agent = 'eleanor 0.1.6'
-    values = {'name': 'eleanor',
-              'language': 'Python' }
-    headers = {'User-Agent': user_agent}
+    if localdir is not None:
 
-    data = urllib.parse.urlencode(values)
-    data = data.encode('ascii')
+        guide = 'pointingModel_{0:04d}_{1}-{2}.txt'.format(sector, camera,
+                                                           chip)
+        guide = os.path.join(localdir, guide)
+        with open(guide, 'r') as ff:
+            pointing = ff.read()
+    else:
+        user_agent = 'eleanor 0.1.6'
+        values = {'name': 'eleanor',
+                  'language': 'Python' }
+        headers = {'User-Agent': user_agent}
 
-    guide_link = 'https://users.flatironinstitute.org/dforeman/public_www/tess/postcards_test/s{0:04d}/pointing_model/pointingModel_{0:04d}_{1}-{2}.txt'.format(sector, camera, chip)
+        data = urllib.parse.urlencode(values)
+        data = data.encode('ascii')
 
-    req = urllib.request.Request(guide_link, data, headers)
-    with urllib.request.urlopen(req) as response:
-        pointing = response.read().decode('utf-8')
+        guide_link = 'https://users.flatironinstitute.org/dforeman/public_www/tess/postcards_test/s{0:04d}/pointing_model/pointingModel_{0:04d}_{1}-{2}.txt'.format(sector, camera, chip)
 
-    pointing = Table.read(pointing, format='ascii.basic') # guide to postcard locations
+        req = urllib.request.Request(guide_link, data, headers)
+        with urllib.request.urlopen(req) as response:
+            pointing = response.read().decode('utf-8')
+
+        pointing = Table.read(pointing, format='ascii.basic') # guide to postcard locations
     return pointing
 
 

--- a/eleanor/mast.py
+++ b/eleanor/mast.py
@@ -220,10 +220,13 @@ def tic_by_contamination(pos, r, contam, tmag_lim):
     print(request)
     blob = {}
     while 'fields' not in blob:
-        headers, outString = mastQuery(request)
-        blob = json.loads(outString)
-        if 'fields' not in blob:
-            print(blob)
-            print("retrying...")
-            time.sleep(30)
+        try:
+            headers, outString = mastQuery(request)
+            blob = json.loads(outString)
+            if 'fields' not in blob:
+                print(blob)
+                print("retrying...")
+                time.sleep(30)
+        except:
+            blob = {}
     return jsonTable(blob)

--- a/eleanor/source.py
+++ b/eleanor/source.py
@@ -122,6 +122,9 @@ class Source(object):
     tc : bool, optional
         If True, use a TessCut cutout to produce postcards rather than downloading the eleanor
         postcard data products.
+    localdir: str, optional
+        Only used when running a complete eleanor pipeline completely locally.
+        Path to the full local set of postcards.
 
     Attributes
     ----------

--- a/eleanor/source.py
+++ b/eleanor/source.py
@@ -71,26 +71,35 @@ def multi_sectors(sectors, tic=None, gaia=None, coords=None, tc=False):
         return objs
 
 
-def load_postcard_guide(sector):
+def load_postcard_guide(sector, localdir=None):
     """Load and return the postcard coordinates guide."""
-    try:
-        user_agent = 'eleanor 0.1.6'
-        values = {'name': 'eleanor',
-                  'language': 'Python' }
-        headers = {'User-Agent': user_agent}
-        
-        data = urllib.parse.urlencode(values)
-        data = data.encode('ascii')
-        
-        guide_link = 'https://users.flatironinstitute.org/dforeman/public_www/tess/postcards_test/s{0:04d}/postcard.guide'.format(sector)
-        
-        req = urllib.request.Request(guide_link, data, headers)
-        with urllib.request.urlopen(req) as response:
-            guide = response.read().decode('utf-8')
-        
-        guide = Table.read(guide, format='ascii.basic') # guide to postcard locations
-    except urllib.error.HTTPError:
-        return None
+    if localdir is not None:
+        try:
+            guide_link = os.path.join(localdir, 's{0:04d}'.format(sector),
+                                      'postcard.guide')
+            guide = Table.read(guide_link, format='ascii.basic')
+        except FileNotFoundError:
+            return None
+    else:
+        try:
+            from .version import __version__
+            user_agent = f'eleanor {__version__}'
+            values = {'name': 'eleanor',
+                      'language': 'Python' }
+            headers = {'User-Agent': user_agent}
+
+            data = urllib.parse.urlencode(values)
+            data = data.encode('ascii')
+
+            guide_link = 'https://users.flatironinstitute.org/dforeman/public_www/tess/postcards_test/s{0:04d}/postcard.guide'.format(sector)
+
+            req = urllib.request.Request(guide_link, data, headers)
+            with urllib.request.urlopen(req) as response:
+                guide = response.read().decode('utf-8')
+
+            guide = Table.read(guide, format='ascii.basic') # guide to postcard locations
+        except urllib.error.HTTPError:
+            return None
     return guide
 
 
@@ -134,7 +143,7 @@ class Source(object):
     all_postcards : list of strs
         Names of all postcards where the source appears.
     """
-    def __init__(self, tic=None, gaia=None, coords=None, fn=None, sector=None, fn_dir=None, tc=False):
+    def __init__(self, tic=None, gaia=None, coords=None, fn=None, sector=None, fn_dir=None, tc=False, localdir=None):
         self.tic       = tic
         self.gaia      = gaia
         self.coords    = coords
@@ -143,6 +152,7 @@ class Source(object):
         self.usr_sec   = sector
         self.tc        = tc
         self.contratio = None
+        self.localdir = localdir
 
         if fn_dir is None:
             self.fn_dir = os.path.join(os.path.expanduser('~'), '.eleanor')
@@ -199,9 +209,9 @@ class Source(object):
             else:
                 assert False, ("Source: one of the following keywords must be given: "
                                "tic, gaia, coords, fn.")
-                
 
-            self.tess_mag = self.tess_mag[0]            
+
+            self.tess_mag = self.tess_mag[0]
             if tc == False:
                 self.locate_on_tess() # sets sector, camera, chip, postcard,
                                   # position_on_chip, position_on_postcard
@@ -209,8 +219,8 @@ class Source(object):
                 self.tesscut_size = 31
                 self.locate_with_tesscut() # sets sector, camera, chip, postcard,
                                   # position_on_chip, position_on_postcard
-            
-                
+
+
         self.ELEANORURL = 'https://users.flatironinstitute.org/dforeman/public_www/tess/postcards_test/s{0:04d}/{1}-{2}/'.format(self.sector,
                                                                                                                                  self.camera,
                                                                                                                                  self.chip)
@@ -251,7 +261,7 @@ class Source(object):
 
         if self.usr_sec is not None:
             if type(self.usr_sec) == int:
-                guide = load_postcard_guide(self.usr_sec)
+                guide = load_postcard_guide(self.usr_sec, localdir=self.localdir)
                 if guide is None:
                     raise SearchError("Sorry, this sector isn't available yet. We're working on it!")
                 else:
@@ -260,7 +270,7 @@ class Source(object):
             # Searches for the most recent sector the object was observed in
             elif self.usr_sec.lower() == 'recent':
                 for s in np.arange(15,0,-1):
-                    guide = load_postcard_guide(s)
+                    guide = load_postcard_guide(s, localdir=self.localdir)
                     if guide is not None:
                         cam_chip_loop(s)
                         if self.sector is not None:
@@ -276,7 +286,7 @@ class Source(object):
         Sets attributes postcard, position_on_postcard, all_postcards.
         """
         self.locate_on_chip()
-        guide = load_postcard_guide(self.sector)
+        guide = load_postcard_guide(self.sector, localdir=self.localdir)
 
         if self.sector is None:
             return
@@ -322,7 +332,7 @@ class Source(object):
         postcard_pos_on_ffi = (guide['CEN_X'][i] - guide['POST_H'][i]/2.,
                                 guide['CEN_Y'][i] - guide['POST_W'][i]/2.)
         self.position_on_postcard = xy - postcard_pos_on_ffi # as accurate as FFI WCS
-        
+
 
     def locate_with_tesscut(self):
         """
@@ -332,7 +342,7 @@ class Source(object):
         ----------
         postcard : list
         postcard_path : str
-        position_on_postcard : list 
+        position_on_postcard : list
         all_postcards : list
         sector : int
         camera : int
@@ -343,11 +353,11 @@ class Source(object):
         self.postcard = []
         self.position_on_postcard = []
         self.all_postcards = []
-        
+
         self.tc = True
-        
+
         coord = SkyCoord(self.coords[0], self.coords[1], unit="deg")
-        
+
         sector_table = Tesscut.get_sectors(coord)
         self.sector = self.usr_sec
 
@@ -365,13 +375,13 @@ class Source(object):
         else:
             self.postcard_path = fn_exists
             cutout = fits.open(fn_exists)
-        
+
         self.cutout   = cutout
         self.postcard = self.postcard_path.split('/')[-1]
 
         xcoord = cutout[1].header['1CRV4P']
         ycoord = cutout[1].header['2CRV4P']
-        
+
         self.position_on_chip = np.array([xcoord, ycoord])
 
 

--- a/eleanor/targetdata.py
+++ b/eleanor/targetdata.py
@@ -45,7 +45,7 @@ class TargetData(object):
         or else will return an aperture one pixel wider than requested so target
         falls on central pixel.
     bkg_size : int, optional
-        Size of box to use for background estimation. If not set, will default to the width of the 
+        Size of box to use for background estimation. If not set, will default to the width of the
         target pixel file.
     crowded_field : bool, optional
         If true, will return a light curve built using a small aperture (not more than 8 pixels in size).
@@ -57,7 +57,10 @@ class TargetData(object):
         Start and end cadence numbers to use for optimal aperture selection.
     try_load: bool, optional
         If true, will search hidden ~/.eleanor directory to see if TPF has already
-        been created. 
+        been created.
+    localdir: str, optional
+        Only used when running a complete eleanor pipeline completely locally.
+        Path to the full local set of postcards.
 
     Attributes
     ----------
@@ -132,21 +135,22 @@ class TargetData(object):
     Extension[2] = (3, N_time) time, raw flux, systematics corrected flux
     """
 
-    def __init__(self, source, height=13, width=13, save_postcard=True, do_pca=False, do_psf=False, 
-                 bkg_size=None, crowded_field=False, cal_cadences=None, try_load=True, language='English'):
+    def __init__(self, source, height=13, width=13, save_postcard=True, do_pca=False, do_psf=False,
+                 bkg_size=None, crowded_field=False, cal_cadences=None, try_load=True, language='English',
+                 localdir=None):
 
-        self.source_info = source 
+        self.source_info = source
         self.language = language
         self.pca_flux = None
         self.psf_flux = None
 
-        if self.source_info.premade is True:
+        if self.source_info.premade:
             self.load(directory=self.source_info.fn_dir)
 
-        else:            
+        else:
             fnf = True
             # Checks to see if file exists already
-            if try_load==True:
+            if try_load:
                 try:
                     default_fn = 'hlsp_eleanor_tess_ffi_tic{0}_s{1:02d}_tess_v{2}_lc.fits'.format(self.source_info.tic,
                                                                                                   self.source_info.sector,
@@ -156,23 +160,28 @@ class TargetData(object):
                 except:
                     pass
 
-            if fnf is True:
+            if fnf:
                 self.aperture = None
-                
-                if source.tc == False:
-                    self.post_obj = Postcard(source.postcard, source.ELEANORURL)
+
+                if not source.tc:
+                    ldir = None
+                    if localdir is not None:
+                        ldir = os.path.join(localdir, f's{source.sector:04d}',
+                                            f'{source.camera}-{source.chip}')
+                    self.post_obj = Postcard(source.postcard, source.ELEANORURL,
+                                             location=ldir)
                 else:
                     self.post_obj = Postcard_tesscut(source.cutout)
-                
+
                 self.ffiindex = self.post_obj.ffiindex
-                self.flux_bkg = self.post_obj.bkg 
+                self.flux_bkg = self.post_obj.bkg
                 self.get_time(source.coords)
 
                 if bkg_size is None:
                     bkg_size = width
 
-                # Uses the contamination ratio for crowded field if available and 
-                # not already set by the user   
+                # Uses the contamination ratio for crowded field if available and
+                # not already set by the user
                 if crowded_field is True:
                     self.crowded_field = 1
                 else:
@@ -186,19 +195,23 @@ class TargetData(object):
                     self.cal_cadences = (0, len(self.post_obj.time))
                 else:
                     self.cal_cadences = cal_cadences
-            
+
                 try:
-                    self.pointing_model = load_pointing_model(source.sector, source.camera, source.chip)
+                    ldir2 = None
+                    if localdir is not None:
+                        ldir2 = os.path.join(localdir, f's{source.sector:04d}',
+                                             'pointing_model')
+                    self.pointing_model = load_pointing_model(source.sector, source.camera, source.chip, localdir=ldir2)
                 except:
                     self.pointing_model = None
-                    
+
                 self.get_tpf_from_postcard(source.coords, source.postcard, height, width, bkg_size, save_postcard, source)
                 self.set_quality()
-                self.get_cbvs()
-            
+                self.get_cbvs(localdir=localdir)
+
 
                 self.create_apertures(height, width)
-            
+
                 self.get_lightcurve()
 
                 if do_pca == True:
@@ -213,22 +226,22 @@ class TargetData(object):
                     self.psf_flux = None
 
                 self.center_of_mass()
-            
+
                 self.set_header()
 
 
     def get_time(self, coords):
         """Gets time, including light travel time correction to solar system barycenter for object given location"""
         t0 = self.post_obj.time - self.post_obj.barycorr
-        
+
         ra = Angle(coords[0], u.deg)
         dec = Angle(coords[1], u.deg)
-        
+
         greenwich = coord.EarthLocation.of_site('greenwich')
         times = time.Time(t0+2457000, format='jd',
                    scale='utc', location=greenwich)
         ltt_bary = times.light_travel_time(SkyCoord(ra, dec)).value
-        
+
         self.time = t0 + ltt_bary
         self.barycorr = ltt_bary
 
@@ -240,9 +253,9 @@ class TargetData(object):
         self.centroid_ys = None
 
         xy = WCS(self.post_obj.header).all_world2pix(pos[0], pos[1], 1)
-        
+
         # Apply the pointing model to each cadence to find the centroids
-        
+
         if self.pointing_model is None:
             self.centroid_xs = np.zeros_like(self.post_obj.time)
             self.centroid_ys = np.zeros_like(self.post_obj.time)
@@ -254,12 +267,12 @@ class TargetData(object):
                 centroid_ys.append(new_coords[0][1])
             self.centroid_xs = np.array(centroid_xs)
             self.centroid_ys = np.array(centroid_ys)
-        
+
         # Define tpf as region of postcard around target
         med_x, med_y = np.nanmedian(self.centroid_xs), np.nanmedian(self.centroid_ys)
 
         med_x, med_y = int(np.round(med_x,0)), int(np.round(med_y,0))
-        
+
         if source.tc == False:
 
             post_flux = np.transpose(self.post_obj.flux, (2,0,1))
@@ -270,7 +283,7 @@ class TargetData(object):
 
 
         self.cen_x, self.cen_y = med_x, med_y
-        
+
         y_length, x_length = int(np.floor(height/2.)), int(np.floor(width/2.))
         y_bkg_len, x_bkg_len = int(np.floor(bkg_size/2.)), int(np.floor(bkg_size/2.))
 
@@ -278,12 +291,12 @@ class TargetData(object):
         y_upp_lim = med_y+y_length+1
         x_low_lim = med_x-x_length
         x_upp_lim = med_x+x_length+1
-        
+
         y_low_bkg = med_y-y_bkg_len
         y_upp_bkg = med_y+y_bkg_len + 1
         x_low_bkg = med_x-x_bkg_len
         x_upp_bkg = med_x+x_bkg_len + 1
-    
+
 
         if height % 2 == 0 or width % 2 == 0:
             warnings.warn('We force our TPFs to have an odd height and width so we can properly center our apertures.')
@@ -299,7 +312,7 @@ class TargetData(object):
             y_upp_lim = post_y_upp+1
         if x_upp_lim >  post_x_upp:
             x_upp_lim = post_x_upp+1
-            
+
         if y_low_bkg <= 0:
             y_low_bkg = 0
         if x_low_bkg <= 0:
@@ -309,9 +322,9 @@ class TargetData(object):
         if x_upp_bkg >  post_x_upp:
             x_upp_bkg = post_x_upp+1
 
-            
+
         if source.tc == False:
-            
+
             if (x_low_lim==0) or (y_low_lim==0) or (x_upp_lim==post_x_upp) or (y_upp_lim==post_y_upp):
                 warnings.warn("The size postage stamp you are requesting falls off the edge of the postcard.")
                 warnings.warn("WARNING: Your postage stamp may not be centered.")
@@ -319,25 +332,25 @@ class TargetData(object):
             self.tpf     = post_flux[:, y_low_lim:y_upp_lim, x_low_lim:x_upp_lim]
             self.bkg_tpf = post_flux[:, y_low_bkg:y_upp_bkg, x_low_bkg:x_upp_bkg]
             self.tpf_err = post_err[: , y_low_lim:y_upp_lim, x_low_lim:x_upp_lim]
-            
-        else:            
+
+        else:
             if (height > 31) or (width > 31):
                 raise ValueError("Maximum allowed TPF size is 31 x 31 pixels.")
 
             self.tpf     = post_flux[:, 15-y_length:15+y_length+1, 15-x_length:15+x_length+1]
             self.bkg_tpf = post_flux
-            self.tpf_err = post_err[:, 15-y_length:15+y_length+1, 15-x_length:15+x_length+1]           
-            
+            self.tpf_err = post_err[:, 15-y_length:15+y_length+1, 15-x_length:15+x_length+1]
+
         self.dimensions = np.shape(self.tpf)
-        
-        
+
+
         summed_tpf = np.nansum(self.tpf, axis=0)
         mpix = np.unravel_index(summed_tpf.argmax(), summed_tpf.shape)
         if np.abs(mpix[0] - x_length) > 1:
             self.crowded_field = 1
         if np.abs(mpix[1] - y_length) > 1:
             self.crowded_field = 1
-            
+
 
         self.bkg_subtraction()
 
@@ -365,7 +378,7 @@ class TargetData(object):
         pickle_dict = pickle.load(pickle_in)
         self.aperture_names = np.array(list(pickle_dict.keys()))
         all_apertures  = np.array(list(pickle_dict.values()))
-        
+
 
         default = 13
 
@@ -428,7 +441,7 @@ class TargetData(object):
             self.tpf_flux_bkg.append(bkg_value)
 
         self.tpf_flux_bkg = np.array(self.tpf_flux_bkg)
-        
+
 
 
     def get_lightcurve(self, aperture=None):
@@ -452,7 +465,7 @@ class TargetData(object):
             for cad in range(len(self.tpf)):
                 lc[cad]     = np.nansum( self.tpf[cad] * mask)
                 lc_err[cad] = np.sqrt( np.nansum( self.tpf_err[cad]**2 * mask))
-            self.raw_flux   = np.array(lc) 
+            self.raw_flux   = np.array(lc)
             self.corr_flux  = self.corrected_flux(flux=lc, skip=50)
             self.flux_err   = np.array(lc_err)
             return
@@ -471,23 +484,23 @@ class TargetData(object):
             all_corr_lc_pc_sub = np.copy(all_raw_lc_pc_sub)
             all_raw_lc_tpf_sub = np.zeros((len(self.all_apertures), len(self.tpf)))
             all_corr_lc_tpf_sub = np.copy(all_raw_lc_tpf_sub)
-            
+
             for epoch in range(len(self.time)):
                 self.tpf[epoch] -= self.tpf_flux_bkg[epoch]
 
-            pc_stds = np.ones(len(self.all_apertures)) 
-            tpf_stds = np.ones(len(self.all_apertures)) 
-            
-            ap_size = np.nansum(self.all_apertures, axis=(1,2))
-            
+            pc_stds = np.ones(len(self.all_apertures))
+            tpf_stds = np.ones(len(self.all_apertures))
 
-            for a in range(len(self.all_apertures)):       
+            ap_size = np.nansum(self.all_apertures, axis=(1,2))
+
+
+            for a in range(len(self.all_apertures)):
                 for cad in range(len(self.tpf)):
                     try:
                         all_lc_err[a, cad]   = np.sqrt( np.nansum( self.tpf_err[cad]**2 * self.all_apertures[a] ))
                         all_raw_lc_tpf_sub[a, cad]   = np.nansum( (self.tpf[cad]) * self.all_apertures[a] )
                         all_raw_lc_pc_sub[a, cad]  = np.nansum( (self.tpf[cad] + self.tpf_flux_bkg[cad]) * self.all_apertures[a] )
-                        
+
                     except ValueError:
                         continue
 
@@ -503,7 +516,7 @@ class TargetData(object):
                 lc_obj_tpf = lightcurve.LightCurve(time = self.time[q][self.cal_cadences[0]:self.cal_cadences[1]],
                                        flux = all_corr_lc_tpf_sub[a][q][self.cal_cadences[0]:self.cal_cadences[1]])
                 flat_lc_tpf = lc_obj_tpf.flatten(polyorder=2, window_length=51)
-                
+
                 tpf_stds[a] =  np.std(flat_lc_tpf.flux)
 
                 lc_obj_pc = lightcurve.LightCurve(time = self.time[q][self.cal_cadences[0]:self.cal_cadences[1]],
@@ -516,7 +529,7 @@ class TargetData(object):
             self.all_raw_lc  = np.array(all_raw_lc_pc_sub)
             self.all_lc_err  = np.array(all_lc_err)
             self.all_corr_lc = np.array(all_corr_lc_pc_sub)
-            
+
             if self.language == 'Australian':
                 for i in range(len(self.all_raw_lc)):
                     med = np.nanmedian(self.all_raw_lc[i])
@@ -532,7 +545,7 @@ class TargetData(object):
 
             best_ind_tpf = np.where(tpf_stds == np.min(tpf_stds))[0][0]
             best_ind_pc  = np.where(pc_stds == np.min(pc_stds))[0][0]
-            
+
 
             ## Checks if postcard or tpf level bkg subtraction is better ##
             ## Prints bkg_type to TPF header ##
@@ -564,22 +577,29 @@ class TargetData(object):
                                 "Or, create a custom aperture using the function TargetData.custom_aperture(). See documentation for inputs.")
 
         return
-    
 
-    def get_cbvs(self):
+    def get_cbvs(self, localdir=None):
         """ Obtains the cotrending basis vectors (CBVs) as convolved down from the short-cadence targets.
         Parameters
         ----------
         """
-        
+
         try:
-            matrix_file = urlopen('https://archipelago.uchicago.edu/tess_postcards/metadata/s{0:04d}/cbv_components_s{0:04d}_{1:04d}_{2:04d}.txt'.format(self.source_info.sector,
-                                                                                                                                                         self.source_info.camera,
-                                                                                                                                                         self.source_info.chip))
-            A = [float(x) for x in matrix_file.read().decode('utf-8').split()]
-            cbvs = np.asarray(A)
-            self.cbvs = np.reshape(cbvs, (len(self.time), 16))
-            
+            if localdir is not None:
+                ldir = os.path.split(os.path.split(__file__)[0])[0]
+                matrix_file = 'metadata/s{0:04d}/cbv_components_s{0:04d}_{1:04d}_{2:04d}.txt'.format(
+                    self.source_info.sector, self.source_info.camera,
+                    self.source_info.chip)
+                matrix_file = os.path.join(ldir, matrix_file)
+                self.cbvs = np.loadtxt(matrix_file)
+            else:
+                matrix_file = urlopen('https://archipelago.uchicago.edu/tess_postcards/metadata/s{0:04d}/cbv_components_s{0:04d}_{1:04d}_{2:04d}.txt'.format(self.source_info.sector,
+                                                                                                                                                             self.source_info.camera,
+                                                                                                                                                             self.source_info.chip))
+                A = [float(x) for x in matrix_file.read().decode('utf-8').split()]
+                cbvs = np.asarray(A)
+                self.cbvs = np.reshape(cbvs, (len(self.time), 16))
+
         except:
             self.cbvs = np.zeros((len(self.time), 16))
         return
@@ -615,7 +635,7 @@ class TargetData(object):
             c_frame = [cen[0]+c_0[0], cen[1]+c_0[1]]
             self.x_com.append(c_frame[0])
             self.y_com.append(c_frame[1])
-            
+
         self.x_com = np.array(self.x_com)
         self.y_com = np.array(self.y_com)
 
@@ -675,7 +695,7 @@ class TargetData(object):
         import tensorflow as tf
         from .models import Gaussian, Moffat
         from tqdm import tqdm
-        
+
         tf.logging.set_verbosity(tf.logging.ERROR)
 
         if data_arr is None:
@@ -723,24 +743,24 @@ class TargetData(object):
             a = tf.Variable(initial_value=1., dtype=tf.float64)
             b = tf.Variable(initial_value=0., dtype=tf.float64)
             c = tf.Variable(initial_value=1., dtype=tf.float64)
-        
+
 
             if nstars == 1:
                 mean = gaussian(flux, xc[0]+xshift, yc[0]+yshift, a, b, c)
             else:
                 mean = [gaussian(flux[j], xc[j]+xshift, yc[j]+yshift, a, b, c) for j in range(nstars)]
                 mean = np.sum(mean, axis=0)
-                
+
             var_list = [flux, xshift, yshift, a, b, c, bkg]
-            
-            var_to_bounds = {flux: (0, np.infty), 
+
+            var_to_bounds = {flux: (0, np.infty),
                              xshift: (-1.0, 1.0),
                              yshift: (-1.0, 1.0),
                              a: (0, np.infty),
                              b: (-0.5, 0.5),
                              c: (0, np.infty)
                             }
-            
+
         elif model == 'moffat':
 
             moffat = Moffat(shape=data_arr.shape[1:], col_ref=0, row_ref=0)
@@ -749,17 +769,17 @@ class TargetData(object):
             b = tf.Variable(initial_value=0., dtype=tf.float64)
             c = tf.Variable(initial_value=1., dtype=tf.float64)
             beta = tf.Variable(initial_value=1, dtype=tf.float64)
-        
+
 
             if nstars == 1:
                 mean = moffat(flux, xc[0]+xshift, yc[0]+yshift, a, b, c, beta)
             else:
                 mean = [moffat(flux[j], xc[j]+xshift, yc[j]+yshift, a, b, c, beta) for j in range(nstars)]
                 mean = np.sum(mean, axis=0)
-                
+
             var_list = [flux, xshift, yshift, a, b, c, beta, bkg]
-            
-            var_to_bounds = {flux: (0, np.infty), 
+
+            var_to_bounds = {flux: (0, np.infty),
                              xshift: (-2.0, 2.0),
                              yshift: (-2.0, 2.0),
                              a: (0, 3.0),
@@ -767,15 +787,15 @@ class TargetData(object):
                              c: (0, 3.0),
                              beta: (0, 10)
                             }
-            
+
 
             betaout = np.zeros(len(data_arr))
-            
+
 
         else:
             raise ValueError('This model is not incorporated yet!') # we probably want this to be a warning actually,
                                                                     # and a gentle return
-                
+
         aout = np.zeros(len(data_arr))
         bout = np.zeros(len(data_arr))
         cout = np.zeros(len(data_arr))
@@ -799,10 +819,10 @@ class TargetData(object):
 
         sess = tf.Session(config=tf.ConfigProto(device_count={'GPU': 0}))
         sess.run(tf.global_variables_initializer())
-        
 
 
-        
+
+
         optimizer = tf.contrib.opt.ScipyOptimizerInterface(nll, var_list, method='TNC', tol=1e-4, var_to_bounds=var_to_bounds)
 
         fout = np.zeros((len(data_arr), nstars))
@@ -816,7 +836,7 @@ class TargetData(object):
 
             fout[i] = sess.run(flux)
             bkgout[i] = sess.run(bkg)
-            
+
             if model == 'gaussian':
                 aout[i] = sess.run(a)
                 bout[i] = sess.run(b)
@@ -824,7 +844,7 @@ class TargetData(object):
                 xout[i] = sess.run(xshift)
                 yout[i] = sess.run(yshift)
                 llout[i] = sess.run(nll, feed_dict={data:data_arr[i], derr:err_arr[i], bkgval:bkg_arr[i]})
-                
+
             if model == 'moffat':
                 aout[i] = sess.run(a)
                 bout[i] = sess.run(b)
@@ -833,7 +853,7 @@ class TargetData(object):
                 yout[i] = sess.run(yshift)
                 llout[i] = sess.run(nll, feed_dict={data:data_arr[i], derr:err_arr[i], bkgval:bkg_arr[i]})
                 betaout[i] = sess.run(beta)
-            
+
 
         sess.close()
 
@@ -843,7 +863,7 @@ class TargetData(object):
             self.psf_flux = (np.nanmedian(self.psf_flux) - self.psf_flux) + np.nanmedian(self.psf_flux)
 
         self.psf_bkg = bkgout
-        
+
         if verbose:
             if model == 'gaussian':
                 self.psf_a = aout
@@ -967,20 +987,20 @@ class TargetData(object):
 
         if flux is None:
             flux = self.raw_flux
-            
+
         if bkg is None:
             bkg = self.flux_bkg
-            
+
         if pca == True:
             flux = self.raw_flux - bkg*np.sum(self.aperture)
 
         flux = np.array(flux)
-        
+
         med = np.nanmedian(flux)
 
         quality = self.quality
 
-        cx = self.centroid_xs 
+        cx = self.centroid_xs
         cy = self.centroid_ys
         t  = self.time-self.time[0]
 
@@ -1019,19 +1039,19 @@ class TargetData(object):
             cy = cy[mask]
             cx -= np.median(cx)
             cy -= np.median(cy)
-            
+
 
             bkg_use = bkg[mask]
             bkg_use -= np.min(bkg_use)
-            
+
             vv = self.cbvs[mask][:,0:modes]
-                
-        
-                   
+
+
+
             if pca == False:
                 cm = np.column_stack((t[mask][qm][skip:], np.ones_like(t[mask][qm][skip:])))
                 cm_full = np.column_stack((t[mask], np.ones_like(t[mask])))
-                
+
                 if np.std(vv) > 1e-10:
                     cm = np.column_stack((cm, vv[qm][skip:]))
                     cm_full = np.column_stack((cm_full, vv))
@@ -1044,9 +1064,9 @@ class TargetData(object):
                 if np.std(cx) > 1e-10:
                     cm = np.column_stack((cm, cx[qm][skip:], cy[qm][skip:], cx[qm][skip:]**2, cy[qm][skip:]**2))
                     cm_full = np.column_stack((cm_full, cx, cy, cx**2, cy**2))
-                
+
             else:
-                
+
                 cm = np.column_stack((vv[qm][skip:], np.ones_like(t[mask][qm][skip:])))
                 cm_full = np.column_stack((vv, np.ones_like(t[mask])))
 
@@ -1148,13 +1168,13 @@ class TargetData(object):
         """
         if self.language == 'Australian':
             raise ValueError("These light curves are upside down. Please don't save them ...")
-        
+
         self.set_header()
 
         # if the user did not specify a directory, set it to default
         if directory is None:
             directory = self.fetch_dir()
-            
+
         raw       = [e+'_raw'  for e in self.aperture_names]
         errors    = [e+'_err'  for e in self.aperture_names]
         corrected = [e+'_corr' for e in self.aperture_names]
@@ -1179,8 +1199,8 @@ class TargetData(object):
         if self.bkg_type == "PC_LEVEL":
             ext1['FLUX_BKG'] = self.flux_bkg
         else:
-            ext1['FLUX_BKG'] = self.flux_bkg + self.tpf_flux_bkg 
-        
+            ext1['FLUX_BKG'] = self.flux_bkg + self.tpf_flux_bkg
+
 
         if self.pca_flux is not None:
             ext1['PCA_FLUX'] = self.pca_flux
@@ -1233,7 +1253,7 @@ class TargetData(object):
             directory = self.fetch_dir()
         if fn is None:
             fn = self.source_info.fn
-            
+
         hdu = fits.open(os.path.join(directory, fn))
         hdr = hdu[0].header
         self.header = hdr
@@ -1279,7 +1299,7 @@ class TargetData(object):
         self.all_raw_lc  = []
         self.all_corr_lc = []
         self.all_lc_err  = []
-        
+
         names = []
         for i in cols:
             name = ('_').join(i.split('_')[0:-1])
@@ -1307,7 +1327,7 @@ class TargetData(object):
             self.post_obj =Postcard_tesscut(self.source_info.cutout,
                                             location=self.source_info.postcard_path)
 
-                
+
         self.get_cbvs()
 
         return

--- a/make_postcard_guide.py
+++ b/make_postcard_guide.py
@@ -1,0 +1,92 @@
+import sys
+import numpy as np
+from astropy.io import fits, ascii
+from astropy.table import Table
+import os, tqdm
+from glob import glob
+
+
+def get_headers(cards, exists=False, t=None):
+    for i in tqdm.tqdm(range(len(cards)), total=len(cards)):
+        try:
+            hdr = fits.open(cards[i])[1].header
+            key = 'TMOFST{0}{1}'.format(hdr['CAMERA'], hdr['CCD'])
+
+            sector = os.path.split(cards[i])[-1].split("-")[1]
+
+            # Initiate table using first postcard
+            if i == 0 and not exists:
+                names, counts = [], []
+                hdrKeys = [k for k in hdr.keys() if (not k.startswith('TMOFST') and len(k) > 0)]
+                for k in range(len(hdrKeys)):
+                    if hdrKeys[k] not in names:
+                        names.append(hdrKeys[k])
+                        counts.append(k)
+                # names.append('SECTOR')
+                names.append('POSTNAME')
+                names.append('TMOFST')
+
+                counts = np.array(counts)
+
+                dtype = ['S80' for _ in range(len(names))]
+                t = Table(names=names, dtype=dtype)
+
+            elif i == 0 and exists:
+                names = t.colnames
+                counts = np.arange(len(names))
+                hdrKeys = [k for k in hdr.keys() if not k.startswith('TMOFST')]
+
+            row = np.array([hdr.get(k, 0) for k in hdrKeys])
+            row[hdrKeys.index('COMMENT')] = row[hdrKeys.index('COMMENT')][0]
+            row = row[counts]
+            # row = np.append(row, sector)
+            row = np.append(row, os.path.split(cards[i])[1])
+            row = np.append(row, hdr[key])
+            if exists:
+                sec_ind = [i for i in np.arange(0,len(names),1) if 'SECTOR' in names[i]][0]
+                cam_ind = [i for i in np.arange(0,len(names),1) if 'CAMERA' in names[i]][0]
+                ccd_ind = [i for i in np.arange(0,len(names),1) if 'CCD'    in names[i]][0]
+                file_check = [row[sec_ind], int(row[cam_ind]), int(row[ccd_ind])]
+
+                checker = 0
+                for j in range(len(t)):
+                    check = [t['SECTOR'][j], t['CAMERA'][j], t['CCD'][j]]
+                    if check==file_check:
+                        checker += 1
+                if checker == 0:
+                    t.add_row(row)
+
+            else:
+                t.add_row(row)
+
+        except:
+            print(key, cards[i])
+            raise
+    return t
+
+
+if len(sys.argv) > 1:
+    # directory to place the output file
+    dirname = sys.argv[1]
+else:
+    raise Exception('must be called from command line')
+
+fn_output = 'postcard.guide'
+fn_path = os.path.join(dirname, fn_output)
+exists = os.path.exists(fn_path)
+if exists:
+    os.remove(fn_path)
+    exists = False
+
+ffis = glob(os.path.join(dirname, '*', '*eleanor*postcard*[0-9]_pc.fits'))
+
+if exists:
+    t = Table.read(fn_path, format='ascii')
+    table = get_headers(ffis, exists=exists, t=t)
+else:
+    table = get_headers(ffis)
+
+ascii.write(table, fn_path, overwrite=True)
+
+t = Table.read(fn_path, format='ascii')
+print(len(t['SECTOR']))


### PR DESCRIPTION
This brings in everything needed to run eleanor completely locally without changing any default functionality.

I add 2 files: 

1. convolve_cbvs.py which allows for creation of 30-minute CBVs convolved from the official TESS 2-minute ones. I believe this is a script you wrote, but hadn't actually included in this repo or in eleanor-tools.

2. make_postcard_guide.py: This just allows for creation of the postcard guides based off of locally created postcards. This might become obsolete anyway if you eventually end up removing guides.



Then I add in an optional `localdir` argument to Source and TargetData, so that it will look in that directory for local postcards rather than going off to the internet to fetch them from somewhere. No functionality should change at all to anything if that argument isn't passed into those functions.