### PR TITLE
Bugfix in Source class, updated Tess-Point for older installs of Eleanor

### DIFF
--- a/eleanor/source.py
+++ b/eleanor/source.py
@@ -211,8 +211,9 @@ class Source(object):
                 assert False, ("Source: one of the following keywords must be given: "
                                "tic, gaia, coords, fn.")
                 
-
-            self.tess_mag = self.tess_mag[0]            
+            if isinstance(self.tess_mag,list):
+                self.tess_mag = self.tess_mag[0] 
+                
             self.locate_on_tess()
             self.tesscut_size = 31
             

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'mplcursors', 'photutils>=0.7', 'tqdm', 'lightkurve>=1.1.0', 'astropy>=3.2.3',
         'astroquery', 'bokeh', 'fitsio', 'pandas',
         'setuptools>=41.0.0', 
-        'tensorflow<=1.14.0', 'vaneska', 'beautifulsoup4>=4.6.0', 'tess-point'],
+        'tensorflow<=1.14.0', 'vaneska', 'beautifulsoup4>=4.6.0', 'tess-point>=0.3.6'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
Hi,

these are two small changes, that should do two things:

1) There was a bug in source.py. The tess_mag is set to 999 if no function is provided in the initialization of the class. This can be especially an issue if you use eleanor.multi_sectors. I added a small check on that variable, so that the subscript is only done, if that variable is truly an int.

2) While updating eleanor i had an old install of tess_point, hence not allowing to extract some targets, that are in sector 16. I simply added a greater equal for tess_point to the latest version in the setup.py