### PR TITLE
Fix to allow S20 Update() to work.

### DIFF
--- a/eleanor/update.py
+++ b/eleanor/update.py
@@ -132,7 +132,7 @@ class Update(object):
     def get_cbvs(self):
         if self.sector <= 6:
             year = 2018
-        elif self.sector <= 19:
+        elif self.sector <= 20:
             year = 2019
         else:
             year = 2020

--- a/eleanor/update.py
+++ b/eleanor/update.py
@@ -126,7 +126,7 @@ class Update(object):
             self.get_cbvs()
             print('CBVs Made')
             print('Success! Sector {:2d} now available.'.format(self.sector))
-            
+            os.remove(manifest['Local Path'][0])
             self.try_next_sector()
             
     def get_cbvs(self):


### PR DESCRIPTION
S20 stretched from the end of 2019 into beginning of 2020. Apparently the MAST CBV file structure, which include a subdirectory by year, puts things into the year the sector started.