### PR TITLE
Replace os.rename with shutil.move in update.py

### DIFF
--- a/eleanor/visualize.py
+++ b/eleanor/visualize.py
@@ -295,27 +295,62 @@ class Visualize(object):
             return YouTubeVideo(id=id, width=900, height=500)
 
 
-    def plot_gaia_overlay(self, magnitude_limit=18, frame=100):
+    def plot_gaia_overlay(self, tic=None, tpf=None, magnitude_limit=18):
         """Check if the source is contaminated."""
 
-        tpf = self.obj.tpf
-        ra, dec = self.obj.source_info.coords
-        image_extent = (ra, ra + tpf.shape[2],
-                        dec, dec + tpf.shape[1])
+        if tic is None:
+            tic = self.obj.source_info.tic
 
-        fig, ax = plt.subplots(1, figsize=(7,7))
-        plt.imshow(tpf[frame], origin='lower', extent=image_extent)
-        fig = self._add_gaia_figure_elements(self.obj, fig, ra, dec, magnitude_limit=magnitude_limit)
+        if tpf is None:
+            tpf = lk.search_tesscut(f'TIC {tic}')[0].download(cutout_size=(self.obj.tpf.shape[1],
+                                                                           self.obj.tpf.shape[2]))
 
-        fig = plt.gcf()
-        fig.patch.set_facecolor('white')
-        fig.set_size_inches(7, 7)
+        fig = tpf.plot(show_colorbar=False, title=f'TIC {tic}')
+        fig = self._add_gaia_figure_elements(tpf, fig, magnitude_limit=magnitude_limit)
 
-        return ax
+        return fig
 
-
-    def _add_gaia_figure_elements(self, obj, fig, ra, dec, magnitude_limit=18):
+    def _add_gaia_figure_elements(self, tpf, fig, magnitude_limit=18):
         """Make the Gaia Figure Elements"""
+        # Get the positions of the Gaia sources
+        c1 = SkyCoord(tpf.ra, tpf.dec, frame='icrs', unit='deg')
+        # Use pixel scale for query size
+        pix_scale = 21.0
+        # We are querying with a diameter as the radius, overfilling by 2x.
+        from astroquery.vizier import Vizier
+        Vizier.ROW_LIMIT = -1
+        result = Vizier.query_region(c1, catalog=["I/345/gaia2"],
+                                     radius=Angle(np.max(tpf.shape[1:]) * pix_scale, "arcsec"))
+        no_targets_found_message = ValueError('Either no sources were found in the query region '
+                                              'or Vizier is unavailable')
+        too_few_found_message = ValueError('No sources found brighter than {:0.1f}'.format(magnitude_limit))
+        if result is None:
+            raise no_targets_found_message
+        elif len(result) == 0:
+            raise too_few_found_message
+        result = result["I/345/gaia2"].to_pandas()
+        result = result[result.Gmag < magnitude_limit]
+        if len(result) == 0:
+            raise no_targets_found_message
+        radecs = np.vstack([result['RA_ICRS'], result['DE_ICRS']]).T
+        coords = tpf.wcs.all_world2pix(radecs, 1) ## TODO, is origin supposed to be zero or one?
+        year = ((tpf.astropy_time[0].jd - 2457206.375) * u.day).to(u.year)
+        pmra = ((np.nan_to_num(np.asarray(result.pmRA)) * u.milliarcsecond/u.year) * year).to(u.arcsec).value
+        pmdec = ((np.nan_to_num(np.asarray(result.pmDE)) * u.milliarcsecond/u.year) * year).to(u.arcsec).value
+        result.RA_ICRS += pmra
+        result.DE_ICRS += pmdec
+
+        # Gently size the points by their Gaia magnitude
+        sizes = 10000.0 / 2**(result['Gmag']/2)
+
+        plt.scatter(coords[:, 0]+tpf.column, coords[:, 1]+tpf.row, c='firebrick', alpha=0.5, edgecolors='r', s=sizes)
+        plt.scatter(coords[:, 0]+tpf.column, coords[:, 1]+tpf.row, c='None', edgecolors='r', s=sizes)
+        plt.xlim([tpf.column, tpf.column+tpf.shape[1]])
+        plt.ylim([tpf.row, tpf.row+tpf.shape[2]])
+
+        return fig
+    """
+    def _add_gaia_figure_elements(self, obj, fig, ra, dec, magnitude_limit=18):
         # Get the positions of the Gaia sources
         c1 = SkyCoord(ra, dec, frame='icrs', unit='deg')
         # Use pixel scale for query size
@@ -348,3 +383,4 @@ class Visualize(object):
         plt.ylabel('dec')
 
         return fig
+    """


### PR DESCRIPTION
I've been running into issues running eleanor on a linux cluster. The `update` script calls `os.rename`, which only works if the object you're trying to rename is on the same drive as where you're making the call. This will break if you're trying to cache the eleanor metadata externally.

I propose replacing `os.rename` with `shutil.move` in `update.py.` This function is able to rename files/directories on remote drives, and is more flexible to use on linux.

---

This PR also includes a fix to the `plot_gaia_overlay` function using lightkurve. Let me know if you'd prefer keeping them separate.

(PS sorry this includes so many deleted white spaces, that's just my IDE's linter 😬)