### PR TITLE
Change pointing model generated file name to match the v2 pointing model looked for in check_pointing

### DIFF
--- a/eleanor/ffi.py
+++ b/eleanor/ffi.py
@@ -470,8 +470,7 @@ class ffi:
             new_coords = use_pointing_model(np.array(xy).T, pointing_model)
             return np.array(new_coords)
 
-
-        pm_fn = 'pointingModel_{0:04d}_{1}-{2}.txt'.format(self.sector, self.camera, self.chip)
+        pm_fn = 's{0:04d}-{1}-{2}_tess_v2_pm.txt'.format(self.sector, self.camera, self.chip)
         
         eleanorpath = os.path.join(os.path.expanduser('~'), '.eleanor')
 


### PR DESCRIPTION
We've noticed that eleanor-tools is still generating pointing models with the old naming format, but eleanor 1.0.4 is looking for a pointing model with "v2" in the file name. This change updates the pointing model file name.

My questions:

1. Did anything actually change between the old pointing models and the v2 ones? Or is the v2 just referencing eleanor postcards v2 and not that the content of the pointing models should in any way be different?

2. It might make sense to move the bulk of this ffi.py file over to eleanor-tools. I didn't do a thorough search, but I believe the only real part of this file used by eleanor is the check_pointing function at the top. The FFI class (the bulk of this file) I believe is only used in postcard/pointing model creation and thus might be a better fit in eleanor-tools and make it easier to track if any changes have been made that would affect postcard creation.