### PR TITLE
fix aperture_contour and add color_by_aperture to pixel_by_pixel

### DIFF
--- a/eleanor/source.py
+++ b/eleanor/source.py
@@ -453,7 +453,7 @@ class Source(object):
                                                                                   self.camera,
                                                                                   self.chip,
                                                                                   ra, dec,
-                                                                                  self.tesscut_size[0], self.tesscut_size[1])
+                                                                                  self.tesscut_size, self.tesscut_size)
         local_path = os.path.join(download_dir, tesscut_fn)
         if os.path.isfile(local_path):
             return local_path

--- a/eleanor/visualize.py
+++ b/eleanor/visualize.py
@@ -107,7 +107,7 @@ class Visualize(object):
         X, Y= np.meshgrid(x[:-1],y[:-1])
         Z = g(X[:-1],Y[:-1])
 
-        plt.contour(Z[::-1], [0.5], colors=ap_color, linewidths=[ap_linewidth],
+        plt.contour(Z, [0.05], colors=ap_color, linewidths=[ap_linewidth],
                     extent=[0-0.5, x[:-1].max()-0.5,0-0.5, y[:-1].max()-0.5])
 
         return fig
@@ -116,7 +116,9 @@ class Visualize(object):
 
     def pixel_by_pixel(self, colrange=None, rowrange=None, cmap='viridis',
                        data_type="corrected", mask=None, xlim=None,
-                       ylim=None, color_by_pixel=False, freq_range=[1/20., 1/0.1]):
+                       ylim=None, color_by_pixel=False, color_by_aperture=True,
+                       freq_range=[1/20., 1/0.1], aperture=None, ap_color='r',
+                       ap_linewidth=2):
         """
         Creates a pixel-by-pixel light curve using the corrected flux.
         Contribution from Oliver Hall.
@@ -179,19 +181,40 @@ class Visualize(object):
 
 
         ## PLOTS TARGET PIXEL FILE ##
+            
         ax = plt.subplot(outer[0])
+        
+        if aperture is None:
+            aperture = self.obj.aperture
 
-        c = ax.imshow(self.flux[100, rowrange[0]:rowrange[1],
-                                colrange[0]:colrange[1]],
-                      vmax=np.percentile(self.flux[100], 95),
+        plotflux = np.nanmedian(self.flux[:, rowrange[0]:rowrange[1], 
+                                          colrange[0]:colrange[1]], axis=0)
+        c = ax.imshow(plotflux,
+                      vmax=np.percentile(plotflux, 95),
                       cmap=cmap)
         divider = make_axes_locatable(ax)
         cax = divider.append_axes('right', size='5%', pad=0.15)
         plt.colorbar(c, cax=cax, orientation='vertical')
+            
+        f = lambda x,y: aperture[int(y),int(x) ]
+        g = np.vectorize(f)
+
+        x = np.linspace(colrange[0],colrange[1], nrows*100)
+        y = np.linspace(rowrange[0],rowrange[1], ncols*100)
+        X, Y= np.meshgrid(x[:-1],y[:-1])
+        Z = g(X[:-1],Y[:-1])
+
+        ax.contour(Z, [0.05], 
+                   colors=ap_color, linewidths=[ap_linewidth],
+                    extent=[0-0.5, nrows-0.5,0-0.5, ncols-0.5])
 
         ## PLOTS PIXEL LIGHT CURVES ##
         for ind in range( int(nrows * ncols) ):
-            ax = plt.Subplot(figure, inner[ind])
+            if ind == 0:                
+                ax = plt.Subplot(figure, inner[ind])
+                origax = ax
+            else:
+                ax = plt.Subplot(figure, inner[ind], sharex=origax)
 
             flux = self.flux[:,i,j]
             time = self.obj.time
@@ -225,6 +248,11 @@ class Visualize(object):
                 color = matplotlib.colors.rgb2hex(rgb)
 
             ax.plot(x, y, c=color)
+            
+            if color_by_aperture and aperture[i,j] > 0:
+                for iax in ['top', 'bottom', 'left', 'right']:
+                    ax.spines[iax].set_color(ap_color)
+                    ax.spines[iax].set_linewidth(ap_linewidth)
 
             j += 1
             if j == colrange[1]:


### PR DESCRIPTION
This does 4 things. 

1. The recent change 3 days ago doesn't fully work, so partially revert that until they can fix the new tesscut_size parameter.

2. Add sharex to pixel_by_pixel so that if you zoom in on a time frame on any of the pixels, it zooms in on all of them. This makes it immensely easier to zoom into regions and see what's going on in all pixels without having to constantly recall the function with different xlim arguments.

3. Fixes the bug in aperture_contour (#196) so that the image of the pixels and the contour lines are indeed the same and not mirrored around the y-axis.

4. Add a `color_by_aperture` to pixel_by_pixel plots. I've been using a hacked version of this myself for months, but I prettied it up to include for real. Basically, it's really nice when looking at pixel by pixel light curves to know where eleanor's aperture is. This adds the aperture onto the pixel image on the left as well as puts a colored border on the pixel by pixel plots on the right that are included in the aperture. Like so:

<img width="1182" alt="Screen Shot 2020-09-21 at 11 02 26 PM" src="https://user-images.githubusercontent.com/6944089/93840477-86634700-fc5e-11ea-8d90-62f9f497399c.png">

I tested it with custom apertures as well as with custom column and row ranges, and I believe it works, though please do confirm. This also shouldn't interfere with the color_by_pixel argument already there.

I set it as on by default because I personally find it incredibly useful and worth having more often than not. I also lowered the aperture contour level to 0.05 instead of the 0.5 previously. Because like I said in #196, I think you allow pixels to have partial weights, but I personally think if the pixel is given any weight it should be part of the aperture contour, not just the pixels with weights > 0.5. Feel free to change that though.