### PR TITLE
Fix the bug when tesscut_size is an integer

### DIFF
--- a/eleanor/source.py
+++ b/eleanor/source.py
@@ -25,7 +25,7 @@ __all__ = ['Source', 'multi_sectors']
 
 
 def multi_sectors(sectors, tic=None, gaia=None, coords=None, name=None, tc=False, local=False, post_dir=None, pm_dir=None,
-                  metadata_path=None, tesscut_size=(31, 31)):
+                  metadata_path=None, tesscut_size=31):
     """Obtain a list of Source objects for a single target, for each of multiple sectors for which the target was observed.
 
     Parameters
@@ -129,7 +129,7 @@ class Source(object):
     """
     def __init__(self, tic=None, gaia=None, coords=None, name=None, fn=None, 
                  sector=None, fn_dir=None, tc=False, local=False, post_dir=None, pm_dir=None,
-                 metadata_path=None, tesscut_size=(31, 31)):
+                 metadata_path=None, tesscut_size=31):
         self.tic       = tic
         self.gaia      = gaia
         self.coords    = coords
@@ -449,11 +449,20 @@ class Source(object):
         ra = format(coords.ra.deg, '.6f')
         dec = format(coords.dec.deg, '.6f')
 
-        tesscut_fn = "tess-s{0:04d}-{1}-{2}_{3}_{4}_{5}x{6}_astrocut.fits".format(self.sector,
+        if isinstance(self.tesscut_size, int):
+            tesscut_fn = "tess-s{0:04d}-{1}-{2}_{3}_{4}_{5}x{6}_astrocut.fits".format(self.sector,
                                                                                   self.camera,
                                                                                   self.chip,
                                                                                   ra, dec,
-                                                                                  self.tesscut_size[0], self.tesscut_size[1])
+                                                                                  self.tesscut_size, self.tesscut_size)
+        else:
+            tesscut_fn = "tess-s{0:04d}-{1}-{2}_{3}_{4}_{5}x{6}_astrocut.fits".format(self.sector,
+                                                                                  self.camera,
+                                                                                  self.chip,
+                                                                                  ra, dec,
+                                                                                  self.tesscut_size[1],
+                                                                                  self.tesscut_size[0])
+
         local_path = os.path.join(download_dir, tesscut_fn)
         if os.path.isfile(local_path):
             return local_path

--- a/eleanor/source.py
+++ b/eleanor/source.py
@@ -25,7 +25,7 @@ __all__ = ['Source', 'multi_sectors']
 
 
 def multi_sectors(sectors, tic=None, gaia=None, coords=None, name=None, tc=False, local=False, post_dir=None, pm_dir=None,
-                  metadata_path=None, tesscut_size=31):
+                  metadata_path=None, tesscut_size=(31, 31)):
     """Obtain a list of Source objects for a single target, for each of multiple sectors for which the target was observed.
 
     Parameters
@@ -129,7 +129,7 @@ class Source(object):
     """
     def __init__(self, tic=None, gaia=None, coords=None, name=None, fn=None, 
                  sector=None, fn_dir=None, tc=False, local=False, post_dir=None, pm_dir=None,
-                 metadata_path=None, tesscut_size=31):
+                 metadata_path=None, tesscut_size=(31, 31)):
         self.tic       = tic
         self.gaia      = gaia
         self.coords    = coords


### PR DESCRIPTION
Sorry, I made a mistake for the file name of the tesscut when tesscut_size is the default value. Now, I fix this bug by adding a condition for the type of tesscut_size.