### PR TITLE
give TargetData a boolean lite flag

### DIFF
--- a/eleanor/targetdata.py
+++ b/eleanor/targetdata.py
@@ -156,6 +156,7 @@ class TargetData(object):
         self.pca_flux = None
         self.psf_flux = None
         self.regressors = regressors
+        self.lite = False
 
         if self.source_info.premade is True:
             self.load(directory=self.source_info.fn_dir)


### PR DESCRIPTION
The visualize class has been changed to check if the TargetData object it was fed is loaded from a lite fits file. However, this raises an error now because the `lite` property is currently only set in the `load` function. It needs to be set to `False` by default in the `__init__` when the object has full access to everything and visualize should work.
https://github.com/afeinstein20/eleanor/blob/bd5b8cdc6d80bda9ebab2b464f07aab24bc93f7f/eleanor/visualize.py#L132-L135