### PR TITLE
update .gitignore for code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ build
 dist
 .cache/
 .coverage
+coverage.xml
+htmlcov
 .eggs
 .ipynb_checkpoints
 *.so


### PR DESCRIPTION
update `.gitignore` for code coverage scenario, e.g., generating html coverage report.
