### PR TITLE
Bugfix for stars near the edge of the detctor

### DIFF
--- a/eleanor/targetdata.py
+++ b/eleanor/targetdata.py
@@ -716,8 +716,11 @@ class TargetData(object):
         best_ind_tpf = np.where(tpf_stds == np.nanmin(tpf_stds))[0][0]
         best_ind_pc  = np.where(pc_stds == np.nanmin(pc_stds))[0][0]
 
-        if self.source_info.tc == False:
-            best_ind_2d = np.where(stds_2d == np.nanmin(stds_2d))[0][0]
+        if not self.source_info.tc:
+            if np.isfinite(stds_2d).any():
+                best_ind_2d = np.where(stds_2d == np.nanmin(stds_2d))[0][0]
+            else:
+                best_ind_2d = None
         else:
             best_ind_2d = None
 

--- a/eleanor/targetdata.py
+++ b/eleanor/targetdata.py
@@ -466,12 +466,14 @@ class TargetData(object):
 
             lmask, lname = lap.to_mask(method='center').to_image(shape=shape), 'rectangle_{}'.format(int(deg))
             tmask, tname = tap.to_mask(method='center').to_image(shape=shape), 'L_{}'.format(int(deg))
+            
+            if lmask is not None and lmask.sum() > 0:
+                all_apertures.append(lmask)
+                aperture_names.append(lname)
 
-            all_apertures.append(lmask)
-            aperture_names.append(lname)
-
-            all_apertures.append(tmask)
-            aperture_names.append(tname)
+            if tmask is not None and tmask.sum() > 0:
+                all_apertures.append(tmask)
+                aperture_names.append(tname)
 
             cap = circle_aperture(center, clist[i])
             rap = square_aperture(center, rlist[i], rlist[i], theta[i])
@@ -480,11 +482,13 @@ class TargetData(object):
                 cmask, cname = cap.to_mask(method=method).to_image(shape=shape), '{}_circle_{}'.format(clist[i], method)
                 rmask, rname = rap.to_mask(method=method).to_image(shape=shape), '{}_square_{}'.format(rlist[i], method)
 
-                all_apertures.append(cmask)
-                aperture_names.append(cname)
-
-                all_apertures.append(rmask)
-                aperture_names.append(rname)
+                if cmask is not None and cmask.sum() > 0:
+                    all_apertures.append(cmask)
+                    aperture_names.append(cname)
+                    
+                if rmask is not None and rmask.sum() > 0:
+                    all_apertures.append(rmask)
+                    aperture_names.append(rname)
 
             deg += 90
 

--- a/eleanor/targetdata.py
+++ b/eleanor/targetdata.py
@@ -27,6 +27,11 @@ from .postcard import Postcard, Postcard_tesscut
 
 __all__  = ['TargetData']
 
+
+class EdgeProblem(Exception):
+    pass
+
+
 class TargetData(object):
     """
     Object containing the light curve, target pixel file, and related information
@@ -228,7 +233,10 @@ class TargetData(object):
                 self.get_cbvs()
 
                 self.create_apertures(self.tpf.shape[1], self.tpf.shape[2])
-
+                if self.all_apertures.size == 0:
+                    raise EdgeProblem('This star falls off the edge of the '
+                                      'detector and we cannot produce a light '
+                                      'curve.')
                 self.get_lightcurve()
 
                 if do_pca == True:

--- a/eleanor/targetdata.py
+++ b/eleanor/targetdata.py
@@ -466,7 +466,7 @@ class TargetData(object):
 
             lmask, lname = lap.to_mask(method='center').to_image(shape=shape), 'rectangle_{}'.format(int(deg))
             tmask, tname = tap.to_mask(method='center').to_image(shape=shape), 'L_{}'.format(int(deg))
-            
+
             if lmask is not None and lmask.sum() > 0:
                 all_apertures.append(lmask)
                 aperture_names.append(lname)
@@ -485,7 +485,7 @@ class TargetData(object):
                 if cmask is not None and cmask.sum() > 0:
                     all_apertures.append(cmask)
                     aperture_names.append(cname)
-                    
+
                 if rmask is not None and rmask.sum() > 0:
                     all_apertures.append(rmask)
                     aperture_names.append(rname)
@@ -1696,7 +1696,7 @@ def get_flattened_sigma(y, maxiter=100, window_size=51, nsigma=4):
     sig = np.std(y)
     m = np.ones_like(y, dtype=bool)
     n = len(y)
-    for n in range(maxiter):
+    for _ in range(maxiter):
         sig = np.std(y[m])
         m = np.abs(y) < nsigma * sig
         if m.sum() == n:


### PR DESCRIPTION
Hey,

So Brian is busy making millions of light curve, and a small handful (~1000 of every million) are failing. Some of them are for obvious reasons (trying to make a light curve of a 15th mag star 1 pixel away from a 5th mag saturated star), but others didn't have any obvious bright stars nearby.

I think I've traced it to most of the times being an edge-of-detector bug where only parts of the apertures are on sky.

One example:

```
star = eleanor.Source(tic=70442414, sector=1)
data = eleanor.TargetData(star, height=15, width=15, do_pca=True)
```

Looking into it, the first problem is that one of the `self.all_apertures` is `None` rather than a 2D array. The other problem is that some of the apertures are actually all 0s, which of course breaks things further down the line. I'm not really sure how that's possible, but it happened. So anyway, my fix is to simply throw away any apertures that come back as `None` or all zeros.
