### PR TITLE
deal with all negative fluxes

### DIFF
--- a/eleanor/targetdata.py
+++ b/eleanor/targetdata.py
@@ -662,13 +662,13 @@ class TargetData(object):
             ## Remove something from all_raw_lc before passing into jitter_corr ##
             try:
                 norm = np.nansum(self.all_apertures[a], axis=1)
-                all_corr_lc_pc_sub[a] = self.corrected_flux(flux=all_raw_lc_pc_sub[a]/np.nanmedian(all_raw_lc_pc_sub[a][all_raw_lc_pc_sub[a] > 0]),
+                all_corr_lc_pc_sub[a] = self.corrected_flux(flux=all_raw_lc_pc_sub[a]/np.nanmedian(np.abs(all_raw_lc_pc_sub[a])),
                                                            bkg=self.flux_bkg[:, None] * norm)
-                all_corr_lc_tpf_sub[a]= self.corrected_flux(flux=all_raw_lc_tpf_sub[a]/np.nanmedian(all_raw_lc_tpf_sub[a][all_raw_lc_tpf_sub[a] > 0]),
+                all_corr_lc_tpf_sub[a]= self.corrected_flux(flux=all_raw_lc_tpf_sub[a]/np.nanmedian(np.abs(all_raw_lc_tpf_sub[a])),
                                                             bkg=self.tpf_flux_bkg[:, None] * norm)
 
                 if self.source_info.tc == False:
-                    all_corr_lc_tpf_2d_sub[a] = self.corrected_flux(flux=all_raw_lc_tpf_2d_sub[a]/np.nanmedian(all_raw_lc_tpf_2d_sub[a][all_raw_lc_tpf_2d_sub[a] > 0]),
+                    all_corr_lc_tpf_2d_sub[a] = self.corrected_flux(flux=all_raw_lc_tpf_2d_sub[a]/np.nanmedian(np.abs(all_raw_lc_tpf_2d_sub[a])),
                                                                     bkg=np.nansum(self.bkg_tpf*self.all_apertures[a], axis=(1,2)))
 
 


### PR DESCRIPTION
Sigh, we're crossing bridges very quickly.

So for some of these faint stars, some (seemingly larger) apertures have all negative fluxes. e.g. for TIC 40342907 here's each aperture and whether it had any positive fluxes (good) or not (bad):
```
1.25_circle_exact good
3_square_exact bad
rectangle_90 good
L_90 good
2.5_circle_center bad
3_square_center bad
2.5_circle_exact bad
3_square_exact bad
rectangle_180 good
L_180 good
3.5_circle_center bad
5_square_center bad
3.5_circle_exact bad
5_square_exact bad
rectangle_270 bad
L_270 bad
4_circle_center bad
4.1_square_center bad
4_circle_exact bad
4.1_square_exact bad
rectangle_0 good
```
I'm not exactly sure what all the apertures mean, but I think the bigger ones are failing. Which I guess kinda makes sense since this star will only have any light in the central one or two pixels and the rest is noise?

I don't know... the background level still seems pretty low compared to the star, at least if I'm interpreting this correctly. Also, why would the PCA come out negative here?

<img width="778" alt="Screen Shot 2022-03-17 at 3 36 19 PM" src="https://user-images.githubusercontent.com/6944089/158881921-3b660985-fc22-4ffb-afdb-129012c7ced1.png">

This is what it looks like using your postcards. Still a negative PCA, but all apertures pass and have at least 1 positive flux, so that's a bit confusing.
<img width="782" alt="Screen Shot 2022-03-17 at 3 38 23 PM" src="https://user-images.githubusercontent.com/6944089/158882279-9010e13b-a769-4033-b4f1-81c167c33d46.png">


Anyway, I'm switching to normalizing by the median of the absolute values of the fluxes. Unless maybe you think we should just throw these apertures away completely?




