### PR TITLE
Get eleanor working for S56 and beyond

### DIFF
--- a/eleanor/maxsector.py
+++ b/eleanor/maxsector.py
@@ -1,1 +1,1 @@
-maxsector = 51
+maxsector = 56

--- a/eleanor/models.py
+++ b/eleanor/models.py
@@ -1,5 +1,4 @@
 import math
-import tensorflow as tf
 from astropy.io import fits as pyfits
 from lightkurve.utils import channel_to_module_output
 import numpy as np
@@ -49,6 +48,7 @@ class Gaussian(Model):
         ----------
         https://en.wikipedia.org/wiki/Gaussian_function#Two-dimensional_Gaussian_function
         """
+        import tensorflow as tf
 
         dx = self.x - xo
         dy = self.y - yo
@@ -62,6 +62,8 @@ class Moffat(Model):
         return self.evaluate(*params)
 
     def evaluate(self, flux, xo, yo, a, b, c, beta):
+        import tensorflow as tf
+
         dx = self.x - xo
         dy = self.y - yo
         psf = tf.divide(1., tf.pow(1. + a * dx ** 2 + 2 * b * dx * dy + c * dy ** 2, beta))

--- a/eleanor/targetdata.py
+++ b/eleanor/targetdata.py
@@ -22,7 +22,6 @@ import os.path
 import warnings
 import pickle
 
-import tensorflow as tf
 from tqdm import tqdm
 
 from .ffi import use_pointing_model, load_pointing_model, centroid_quadratic
@@ -903,6 +902,8 @@ class TargetData(object):
             target, effectively masking other nearby, bright stars. This strategy appears to do a
             reasonable job estimating the background more accurately in relatively crowded regions.
         """
+        import tensorflow as tf
+
         tf.logging.set_verbosity(tf.logging.ERROR)
 
         if data_arr is None:


### PR DESCRIPTION
This is my fix for #261. 

Upon reflection, I decided the easiest approach would be to switch to using the 20-sec targets as the reference point because then you again have an integer 10 20-sec cadences making up the new 200-sec FFI cadence. 

I believe I made all the necessary changes, and it builds locally and seems to work on a test TOI.

Summary of changes:

- Moved the tensorflow imports back inside of functions so that you can import the package without tf being installed.
- Switch to using 20-sec CBVs and 20-sec target for quality flags in sectors 56+.
- Calculate the cadence number correctly.

The big issue I'm having is in choosing the correct 20-s cadences to use in the CBVs/quality flags.

In both cases, you're uncorrecting the BJD correction to compare times? For some reason, that seems to be correct for the CBVs as far as I can tell (the CBV times do seem to not be BJD corrected).

```
cbv_time = array([2825.25051738, 2825.25074886, 2825.25098034, ..., 2853.13893042, 2853.1391619 , 2853.13939338])

target[1].data['time'] = array([2825.25155724, 2825.25178872, 2825.2520202 , ..., 2853.13987331, 2853.14010479, 2853.14033627])

target[1].data['time'] - target[1].data['timecorr'] = array([2825.25051136, 2825.25074284, 2825.25097432, ..., 2853.1389244 , 2853.13915588, 2853.13938736])
```

But in the quality flag section, both the target and your cutout should theoretically be BJD corrected, but you uncorrect both of them. Why is that? 

Which one you choose (BJD or uncorrected for each) changes your matching central 20-sec cadence by ~8 cadences (160s). So in previous sectors you might be off by 1 short cadence one way or the other, but now if you choose the wrong one, you're effectively shifting your quality flags to the wrong 200-sec cadence.

I tried playing around with it and just confused myself more, but I chose to use the BJD corrected times for the quality flag match for now.