### PR TITLE
fix update_max_sector() : update the proper maxsector.py

### DIFF
--- a/eleanor/update.py
+++ b/eleanor/update.py
@@ -77,7 +77,8 @@ def update_max_sector():
     current_sectors = [i for i in html if 's00' in i]
     sectors = [int(i[1:5]) for i in current_sectors]
 
-    with open('maxsector.py', 'w') as tf:
+    codepath = os.path.dirname(__file__)
+    with open(codepath + '/maxsector.py', 'w') as tf:
         tf.write('maxsector = {0}'.format(int(np.nanmax(sectors))))
 
     print("Most recent sector available = ", int(np.nanmax(sectors)))


### PR DESCRIPTION
Currently, `fix update_max_sector()` updates an incorrect `maxsector.py`. It updates `maxsector.py` in the current directory, not the one in `eleanor.__path__`

The PR fixed the logic, making the logic consistent with the similar one at `try_next_sector()`.

