### PR TITLE
A general fix for errors due to cadence mismatch between postcard and metadata (quality flags, ffiindex, CBV)

### DIFF
--- a/eleanor/postcard.py
+++ b/eleanor/postcard.py
@@ -339,17 +339,6 @@ class Postcard_tesscut(object):
         return A
 
     @property
-    def quality_tc(self):
-        """Quality flags from Tesscut without eleanor processing.
-        Used by the workaround for the general problem of
-        https://github.com/afeinstein20/eleanor/issues/267
-        """
-        if 'QUALITY' in self.hdu[1].data.names:
-            return self.hdu[1].data['QUALITY']
-        else:
-            return None
-
-    @property
     def bkg(self):
         sigma_clip = SigmaClip(sigma=3.)
         bkg = MMMBackground(sigma_clip=sigma_clip)

--- a/eleanor/postcard.py
+++ b/eleanor/postcard.py
@@ -335,7 +335,16 @@ class Postcard_tesscut(object):
             if self.header['CAMERA'] == 4:
                 if self.header['CCD'] == 4:
                     A = np.append(A[:6448],A[7910:])
-
+        if len(A) != len(self.flux):
+            # Workaround for general problem of
+            # https://github.com/afeinstein20/eleanor/issues/267
+            warnings.warn(
+                f"Num. of cadences mismatch between postcard TPF ({len(self.flux)})"
+                f" and sector-wide quality flags ({len(A)})"
+                f" for {source_id_str(self)}."
+                " Regenerate them."
+            )
+            A = calc_quality(self.hdu, sector)
         return A
 
     @property
@@ -360,3 +369,69 @@ class Postcard_tesscut(object):
                     A = np.append(A[:6448],A[7910:])
         return A
 
+
+def source_id_str(post_obj):
+    """Helper to return a short string describing the target's source."""
+    h = post_obj.header
+    # the post card does not have the TIC ID (at least not from TessCut)
+    return f"sector {h.get('SECTOR')}, camera {h.get('CAMERA')}, CCD {h.get('CCD')}"
+
+
+def calc_quality(ffi_hdu, sector):
+    """ Uses the quality flags in a 2-minute target to create quality flags
+        for the given postcard.
+    """
+
+    # Note: essentially the same code as Update.get_quality(),
+    # adapted to be used standalone.
+
+    ffi_time = ffi_hdu[1].data['TIME'] # - ffi_hdu[1].data['TIMECORR']
+
+    eleanorpath = os.path.join(os.path.expanduser('~'), '.eleanor')
+    shortCad_fn = eleanorpath + '/metadata/s{0:04d}/target_s{0:04d}.fits'.format(sector)
+
+    # Binary string for values which apply to the FFIs
+    if sector > 26:
+        ffi_apply = int('100000000010101111', 2)
+    else:
+        ffi_apply = int('100010101111', 2)
+
+    # Obtains information for 2-minute target
+    twoMin     = fits.open(shortCad_fn)
+    twoMinTime = twoMin[1].data['TIME'] # - twoMin[1].data['TIMECORR']
+    # finite     = np.isfinite(twoMinTime)
+    twoMinQual = twoMin[1].data['QUALITY']
+
+    # if you only take the finite values, you're not guaranteeing
+    # that the twoMinQual[where - 2:where + 3] is getting 5 contiguous
+    # cadences that you expect. Some might have been removed, and you're
+    # applying quality flags to the wrong cadence.
+
+    # twoMinTime = twoMinTime[finite]
+    # twoMinQual = twoMinQual[finite]
+
+    convolve_ffi = []
+    for i in range(len(ffi_time)):
+        where = np.where(np.abs(ffi_time[i] - twoMinTime) == np.nanmin(np.abs(ffi_time[i] - twoMinTime)))[0][0]
+
+        sflux = np.sum(ffi_hdu[1].data['FLUX'][i])
+        nodata = 0
+        if sflux == 0:
+            nodata = 131072
+
+        if (ffi_time[i] > 1420) and (ffi_time[i] < 1424):
+            nodata = 131072
+
+        if sector < 27:
+            v = np.bitwise_or.reduce(twoMinQual[where-7:where+8])
+        elif sector < 56:
+            # XXX: need to test when TESSCut is available in S27
+            v = np.bitwise_or.reduce(twoMinQual[where - 2:where + 3])
+        else:
+            v = np.bitwise_or.reduce(twoMinQual[where - 5:where + 5])
+        convolve_ffi.append(np.bitwise_or(v, nodata))
+
+    convolve_ffi = np.array(convolve_ffi)
+
+    flags = np.bitwise_and(convolve_ffi, ffi_apply)
+    return flags

--- a/eleanor/postcard.py
+++ b/eleanor/postcard.py
@@ -17,25 +17,25 @@ __all__ = ['Postcard']
 
 class Postcard(object):
     """TESS FFI data for one postcard across one sector.
-    
-    A postcard is an rectangular subsection cut out from the FFIs. 
-    It's like a TPF, but bigger. 
-    The Postcard object contains a stack of these cutouts from all available 
+
+    A postcard is an rectangular subsection cut out from the FFIs.
+    It's like a TPF, but bigger.
+    The Postcard object contains a stack of these cutouts from all available
     FFIs during a given sector of TESS observations.
-    
+
     Parameters
     ----------
     filename : str
         Filename of the downloaded postcard.
     location : str, optional
         Filepath to `filename`.
-    
+
     Attributes
     ----------
     dimensions : tuple
         (`x`, `y`, `time`) dimensions of postcard.
     flux, flux_err : numpy.ndarray
-        Arrays of shape `postcard.dimensions` containing flux or error on flux 
+        Arrays of shape `postcard.dimensions` containing flux or error on flux
         for each pixel.
     time : float
         ?
@@ -44,10 +44,10 @@ class Postcard(object):
     center_radec : tuple
         RA & Dec coordinates of the postcard's central pixel.
     center_xy : tuple
-        (`x`, `y`) coordinates corresponding to the location of 
+        (`x`, `y`) coordinates corresponding to the location of
         the postcard's central pixel on the FFI.
     origin_xy : tuple
-        (`x`, `y`) coordinates corresponding to the location of 
+        (`x`, `y`) coordinates corresponding to the location of
         the postcard's (0,0) pixel on the FFI.
     background2d : np.ndarray
         The 2D modeled background array.
@@ -63,21 +63,21 @@ class Postcard(object):
 
     def plot(self, frame=0, ax=None, scale='linear', **kwargs):
         """Plots a single frame of a postcard.
-        
+
         Parameters
         ----------
         frame : int, optional
             Index of frame. Default 0.
-        
+
         ax : matplotlib.axes.Axes, optional
             Axes on which to plot. Creates a new object by default.
-        
+
         scale : str
             Scaling for colorbar; acceptable inputs are 'linear' or 'log'.
             Default 'linear'.
-        
+
         **kwargs : passed to matplotlib.pyplot.imshow
-        
+
         Returns
         -------
         ax : matplotlib.axes.Axes
@@ -170,19 +170,19 @@ class Postcard(object):
     @property
     def bkg(self):
         return self.hdu[1].data['BKG']
-    
-    @property 
+
+    @property
     def barycorr(self):
         return self.hdu[1].data['BARYCORR']
-    
-    
+
+
     @property
     def ffiindex(self):
         return self.hdu[1].data['FFIINDEX']
-    
+
 class Postcard_tesscut(object):
     """TESS FFI data for one postcard across one sector.
-    
+
     TESSCut is a service from MAST to produce TPF cutouts from the TESS FFIs. If
     `eleanor.Source()` is called with `tc=True`, TESSCut is used to produce a large
     postcard-like cutout region rather than downlading a standard eleanor postcard.
@@ -193,13 +193,13 @@ class Postcard_tesscut(object):
         Filename of the downloaded postcard.
     location : str, optional
         Filepath to `filename`.
-    
+
     Attributes
     ----------
     dimensions : tuple
         (`x`, `y`, `time`) dimensions of postcard.
     flux, flux_err : numpy.ndarray
-        Arrays of shape `postcard.dimensions` containing flux or error on flux 
+        Arrays of shape `postcard.dimensions` containing flux or error on flux
         for each pixel.
     time : float
         ?
@@ -208,10 +208,10 @@ class Postcard_tesscut(object):
     center_radec : tuple
         RA & Dec coordinates of the postcard's central pixel.
     center_xy : tuple
-        (`x`, `y`) coordinates corresponding to the location of 
+        (`x`, `y`) coordinates corresponding to the location of
         the postcard's central pixel on the FFI.
     origin_xy : tuple
-        (`x`, `y`) coordinates corresponding to the location of 
+        (`x`, `y`) coordinates corresponding to the location of
         the postcard's (0,0) pixel on the FFI.
     """
     def __init__(self, cutout, location=None):
@@ -226,21 +226,21 @@ class Postcard_tesscut(object):
 
     def plot(self, frame=0, ax=None, scale='linear', **kwargs):
         """Plots a single frame of a postcard.
-        
+
         Parameters
         ----------
         frame : int, optional
             Index of frame. Default 0.
-        
+
         ax : matplotlib.axes.Axes, optional
             Axes on which to plot. Creates a new object by default.
-        
+
         scale : str
             Scaling for colorbar; acceptable inputs are 'linear' or 'log'.
             Default 'linear'.
-        
+
         **kwargs : passed to matplotlib.pyplot.imshow
-        
+
         Returns
         -------
         ax : matplotlib.axes.Axes
@@ -339,16 +339,27 @@ class Postcard_tesscut(object):
         return A
 
     @property
+    def quality_tc(self):
+        """Quality flags from Tesscut without eleanor processing.
+        Used by the workaround for the general problem of
+        https://github.com/afeinstein20/eleanor/issues/267
+        """
+        if 'QUALITY' in self.hdu[1].data.names:
+            return self.hdu[1].data['QUALITY']
+        else:
+            return None
+
+    @property
     def bkg(self):
         sigma_clip = SigmaClip(sigma=3.)
         bkg = MMMBackground(sigma_clip=sigma_clip)
         b = bkg.calc_background(self.flux, axis=(1,2))
         return b
-    
-    @property 
+
+    @property
     def barycorr(self):
         return self.hdu[1].data['TIMECORR']
-    
+
     @property
     def ffiindex(self):
         sector = self.header['SECTOR']

--- a/eleanor/targetdata.py
+++ b/eleanor/targetdata.py
@@ -862,7 +862,8 @@ class TargetData(object):
             # https://github.com/afeinstein20/eleanor/issues/267
             warnings.warn(
                 f"Num. of cadences mismatch between TPF ({len(self.tpf)})"
-                f" and sector-wide quality flags ({len(self.post_obj.quality)})."
+                f" and sector-wide quality flags ({len(self.post_obj.quality)})"
+                f" for {source_id_str(self)}."
                 " Regnereate them."
             )
             self.quality = calc_quality(self.post_obj.hdu, self.source_info.sector)
@@ -1772,6 +1773,14 @@ def get_flattened_sigma(y, maxiter=100, window_size=51, nsigma=4):
             break
         n = m.sum()
     return sig
+
+
+def source_id_str(target):
+    """Helper to return a short string describing the target's source."""
+    return (
+        f"TIC {target.source_info.tic}, sector {target.source_info.sector}"
+        f" (camera {target.source_info.camera}, CCD {target.source_info.chip})"
+    )
 
 
 def calc_quality(ffi_hdu, sector):

--- a/eleanor/targetdata.py
+++ b/eleanor/targetdata.py
@@ -798,10 +798,26 @@ class TargetData(object):
         """
 
         try:
-            matrix_file = np.loadtxt(self.source_info.eleanorpath +
-            '/metadata/s{0:04d}/cbv_components_s{0:04d}_{1:04d}_{2:04d}.txt'.format(self.source_info.sector,
-                                                                                    self.source_info.camera,
-                                                                                    self.source_info.chip))
+            cbvs_path = self.source_info.eleanorpath + '/metadata/s{0:04d}/cbv_components_s{0:04d}_{1:04d}_{2:04d}.txt'.format(
+                self.source_info.sector,
+                self.source_info.camera,
+                self.source_info.chip
+            )
+            matrix_file = np.loadtxt(cbvs_path)
+            ### print("DBGt", len(matrix_file), len(self.tpf))
+            if len(matrix_file) != len(self.tpf):
+                # Workaround for general problem of
+                # https://github.com/afeinstein20/eleanor/issues/267
+                warnings.warn(
+                    f"Num. of cadences mismatch between postcard TPF ({len(self.tpf)})"
+                    f" and the CBV ({len(matrix_file)})"
+                    f" for sector {self.source_info.sector}, camera {self.source_info.camera}, CCD {self.source_info.chip}."
+                    " Regenerate it."
+                )
+                # re-create, save and reload the CBV using the cadences in the poscard
+                calc_n_save_cbvs(self.post_obj.hdu, self.source_info.sector, run_hdu_camera_ccd_only=True)
+                matrix_file = np.loadtxt(cbvs_path)
+
             cbvs = np.asarray(matrix_file)
             if self.source_info.sector == 65:
                 if self.source_info.camera == 4:
@@ -809,7 +825,13 @@ class TargetData(object):
                         cbvs = np.append(cbvs[:6448],cbvs[7910:])
             self.cbvs = np.reshape(cbvs, (len(self.time), 16))
 
-        except:
+        except Exception as e:
+            warnings.warn(
+                "Unexpected error in loading CBV"
+                f" for sector {self.source_info.sector}, camera {self.source_info.camera}, CCD {self.source_info.chip}."
+                " Use zeros for CBV."
+                f" {type(e).__name__}: {e}"
+            )
             self.cbvs = np.zeros((len(self.time), 16))
         return
 
@@ -1763,3 +1785,91 @@ def get_flattened_sigma(y, maxiter=100, window_size=51, nsigma=4):
             break
         n = m.sum()
     return sig
+
+
+def calc_n_save_cbvs(ffi_hdu, sector, run_hdu_camera_ccd_only=False):
+
+    # Note: essentially the same code as Update.get_cbvs(),
+    # adapted
+    # 1. to be used standalone,
+    # 2. run for a specific camera/ccd only
+
+    from .update import listFD, eleanorpath
+
+    if sector <= 6:
+        year = 2018
+    elif sector <= 20:
+        year = 2019
+    elif sector <= 33:
+        year = 2020
+    elif sector <= 47:
+        year = 2021
+    elif sector <= 60:
+        year = 2022
+    elif sector <= 73:
+        year = 2023
+    else:
+        year = 2024
+
+    url = 'https://archive.stsci.edu/missions/tess/ffi/s{0:04d}/{1}/'.format(sector, year)
+
+    directs = []
+    for file in listFD(url):
+        directs.append(file)
+    directs = np.sort(directs)[1::]
+
+    subdirects = []
+    for file in listFD(directs[0]):
+        subdirects.append(file)
+    subdirects = np.sort(subdirects)[1:-4]
+    if run_hdu_camera_ccd_only:
+        # the camera ccd suffix in the subdir path
+        camera_ccd_suffix = "/{}-{}/".format(ffi_hdu[0].header['CAMERA'], ffi_hdu[0].header['CCD'])
+        subdirects = [s for s in subdirects if s.endswith(camera_ccd_suffix)]
+    ### print("DBGu subdirects=", subdirects)
+
+    cbv_ext = '_cbv.fits'
+    if sector > 55:
+        cbv_ext = '_fast-cbv.fits'
+
+    for i in range(len(subdirects)):
+        file = listFD(subdirects[i], ext=cbv_ext)[0]
+        os.system('curl -O -L {}'.format(file))
+
+    time = ffi_hdu[1].data['TIME'] - ffi_hdu[1].data['TIMECORR']
+
+    files = os.listdir('.')
+    files = [i for i in files if i.endswith(cbv_ext) and
+                's{0:04d}'.format(sector) in i]
+
+    ### print("DBGu files=", files)
+    ### print("DBGu len(files)=", len(files))
+    for c in range(len(files)):
+        # memmap=False as wokaround for https://github.com/afeinstein20/eleanor/issues/204
+        cbv      = fits.open(files[c], memmap=False)
+        camera   = cbv[1].header['CAMERA']
+        ccd      = cbv[1].header['CCD']
+        cbv_time = cbv[1].data['Time']
+
+        new_fn = eleanorpath + '/metadata/s{0:04d}/cbv_components_s{0:04d}_{1:04d}_{2:04d}.txt'.format(sector, camera, ccd)
+
+        convolved = np.zeros((len(time), 16))
+        for i in range(len(time)):
+            g = np.argmin(np.abs(time[i] - cbv_time))
+            for j in range(16):
+                index = 'VECTOR_{0}'.format(j+1)
+                if sector < 27:
+                    cads = np.arange(g-7, g+8, 1)
+                elif sector < 56:
+                    # XXX: need to test when TESSCut becomes available
+                    cads = np.arange(g-2, g+3, 1)
+                else:
+                    cads = np.arange(g - 5, g + 5, 1)
+                convolved[i, j] = np.mean(cbv[1].data[index][cads])
+        ### print("DBGu   saved new_fn=", new_fn);
+        np.savetxt(new_fn, convolved)
+        cbv.close()
+    files = [i for i in files if i.endswith(cbv_ext) and
+                's{0:04d}'.format(sector) in i]
+    for c in range(len(files)):
+        os.remove(files[c])

--- a/eleanor/targetdata.py
+++ b/eleanor/targetdata.py
@@ -860,17 +860,12 @@ class TargetData(object):
         if len(self.post_obj.quality) != len(self.tpf):
             # Workaround for general problem of
             # https://github.com/afeinstein20/eleanor/issues/267
-            warn_msg_prefix = (
+            warnings.warn(
                 f"Num. of cadences mismatch between TPF ({len(self.tpf)})"
                 f" and sector-wide quality flags ({len(self.post_obj.quality)})."
+                " Regnereate them."
             )
-            if self.post_obj.quality_tc is None:
-                raise ValueError(warn_msg_prefix + " Cannot proceed.")
-            else:
-                self.quality = np.array(self.post_obj.quality_tc)
-                warnings.warn(
-                    warn_msg_prefix + " Use quality flags from TPF without eleanor processing."
-                )
+            self.quality = calc_quality(self.post_obj.hdu, self.source_info.sector)
         ### print(f"DBGt set_quality() - #.quality={self.quality.shape} , #.tpf={self.tpf.shape}")
         self.quality[np.nansum(self.tpf, axis=(1,2)) == 0] = 128
 
@@ -1777,3 +1772,63 @@ def get_flattened_sigma(y, maxiter=100, window_size=51, nsigma=4):
             break
         n = m.sum()
     return sig
+
+
+def calc_quality(ffi_hdu, sector):
+    """ Uses the quality flags in a 2-minute target to create quality flags
+        for the given postcard.
+    """
+
+    # Note: essentially the same code as Update.get_quality(),
+    # adapted to be used standalone.
+
+    ffi_time = ffi_hdu[1].data['TIME'] # - ffi_hdu[1].data['TIMECORR']
+
+    eleanorpath = os.path.join(os.path.expanduser('~'), '.eleanor')
+    shortCad_fn = eleanorpath + '/metadata/s{0:04d}/target_s{0:04d}.fits'.format(sector)
+
+    # Binary string for values which apply to the FFIs
+    if sector > 26:
+        ffi_apply = int('100000000010101111', 2)
+    else:
+        ffi_apply = int('100010101111', 2)
+
+    # Obtains information for 2-minute target
+    twoMin     = fits.open(shortCad_fn)
+    twoMinTime = twoMin[1].data['TIME'] # - twoMin[1].data['TIMECORR']
+    # finite     = np.isfinite(twoMinTime)
+    twoMinQual = twoMin[1].data['QUALITY']
+
+    # if you only take the finite values, you're not guaranteeing
+    # that the twoMinQual[where - 2:where + 3] is getting 5 contiguous
+    # cadences that you expect. Some might have been removed, and you're
+    # applying quality flags to the wrong cadence.
+
+    # twoMinTime = twoMinTime[finite]
+    # twoMinQual = twoMinQual[finite]
+
+    convolve_ffi = []
+    for i in range(len(ffi_time)):
+        where = np.where(np.abs(ffi_time[i] - twoMinTime) == np.nanmin(np.abs(ffi_time[i] - twoMinTime)))[0][0]
+
+        sflux = np.sum(ffi_hdu[1].data['FLUX'][i])
+        nodata = 0
+        if sflux == 0:
+            nodata = 131072
+
+        if (ffi_time[i] > 1420) and (ffi_time[i] < 1424):
+            nodata = 131072
+
+        if sector < 27:
+            v = np.bitwise_or.reduce(twoMinQual[where-7:where+8])
+        elif sector < 56:
+            # XXX: need to test when TESSCut is available in S27
+            v = np.bitwise_or.reduce(twoMinQual[where - 2:where + 3])
+        else:
+            v = np.bitwise_or.reduce(twoMinQual[where - 5:where + 5])
+        convolve_ffi.append(np.bitwise_or(v, nodata))
+
+    convolve_ffi = np.array(convolve_ffi)
+
+    flags = np.bitwise_and(convolve_ffi, ffi_apply)
+    return flags


### PR DESCRIPTION
The problem in #267 (in sector 65, camera 4, ccd 4) happens in other cases as well, including sector 78, camera 4, ccd 4 (e.g., TIC 468524320).

This PR provides a general fix, a general version of the sector 65 fix at 05e8e8db9eab865dcfa632406cc1eab3cc3b756b.

When there is a cadence mismatch, the PR: 
1. re-calculates quality flag 
2. re-calculates ffi index 
3. re-calculates CBV, and saves the updated version in `~/.eleanor/metadata` for future use (for the specific sector-camera-ccd)

The re-calculation is based on the similar logic in `update.py`. The codes should probably be re-factorized so that the logic is centralized in one place (rather than having multiple functionally identical copies, especially in light of the tweaks going to be needed to accommodate sectors 83+ data).

---

cc @vbkostov