### PR TITLE
Fix Boundary Calculations & Fix And Enhance The `Visualize()` Class

### DIFF
--- a/eleanor/targetdata.py
+++ b/eleanor/targetdata.py
@@ -331,10 +331,10 @@ class TargetData(object):
         # Fixes the postage stamp if the user requests a size that is too big for the postcard
         if y_low_lim <= 0:
             y_low_lim = 0
-            y_upp_lim = med_y + width + y_low_lim
+            y_upp_lim = width + y_low_lim
         if x_low_lim <= 0:
             x_low_lim = 0
-            x_upp_lim = med_x + height + x_low_lim
+            x_upp_lim = height + x_low_lim
         if y_upp_lim  > post_y_upp:
             y_upp_lim = post_y_upp+1
             y_low_lim = med_y - width + (post_y_upp-med_y)
@@ -352,10 +352,10 @@ class TargetData(object):
 
         if y_low_bkg <= 0:
             y_low_bkg = 0
-            y_upp_bkg = med_y + width + y_low_bkg
+            y_upp_bkg = width + y_low_bkg
         if x_low_bkg <= 0:
             x_low_bkg = 0
-            x_upp_bkg = med_x + height + x_low_bkg
+            x_upp_bkg = height + x_low_bkg
         if y_upp_bkg  > post_y_upp:
             y_upp_bkg = post_y_upp+1
             y_low_bkg = med_y - width + (post_y_upp - med_y)

--- a/eleanor/visualize.py
+++ b/eleanor/visualize.py
@@ -166,7 +166,9 @@ class Visualize(object):
         inner = gridspec.GridSpecFromSubplotSpec(ncols, nrows, hspace=0.1, wspace=0.1,
                                                  subplot_spec=outer[1])
 
-        i, j = rowrange[0], colrange[0]
+        # start from the highest row, to be consistent with the small pixel plot
+        # using `ax.imshow(plotflux, origin='lower', ...)` below
+        i, j = rowrange[1] - 1, colrange[0]
 
         if mask is None:
             q = self.obj.quality == 0
@@ -263,7 +265,7 @@ class Visualize(object):
 
             j += 1
             if j == colrange[1]:
-                i += 1
+                i -= 1
                 j  = colrange[0]
 
             if data_type.lower() != 'amplitude':

--- a/eleanor/visualize.py
+++ b/eleanor/visualize.py
@@ -378,8 +378,22 @@ class Visualize(object):
             tic = self.obj.source_info.tic
 
         if tpf is None:
-            tpf = lk.search_tesscut(f'TIC {tic}')[0].download(cutout_size=(self.obj.tpf.shape[1],
-                                                                           self.obj.tpf.shape[2]))
+            try:
+                search_result = lk.search_tesscut(f'TIC {tic}', sector=self.obj.source_info.sector)
+                if len(search_result) == 0:
+                    raise ValueError("lightkurve.search_tesscut() returned no results.")
+                tpf = search_result.download(cutout_size=(self.obj.tpf.shape[1], self.obj.tpf.shape[2]))
+            except:
+                # If lightkurve.search_tesscut() returns no result or raise an error,
+                # utilize astroquery.mast.TesscutClass.download_cutouts() instead.
+                from astroquery.mast import Tesscut
+                # Download to the same path as lightkurve.search_tesscut().downlaod() does.
+                tesscut_path = os.path.join(os.path.expanduser('~'), '.lightkurve-cache/tesscut')
+                tpf_path_table = Tesscut.download_cutouts(objectname=f'TIC {tic}',
+                                                          size=(self.obj.tpf.shape[1], self.obj.tpf.shape[2]),
+                                                          sector=self.obj.source_info.sector,
+                                                          path=tesscut_path)
+                tpf = lk.read(tpf_path_table['Local Path'].data[0])
 
         if ax is None:
             ax = tpf[cadence].plot(show_colorbar=False, title=f'TIC {tic}')
@@ -414,8 +428,22 @@ class Visualize(object):
             tic = self.obj.source_info.tic
 
         if tpf is None:
-            search_result = lk.search_tesscut(f'TIC {tic}', sector=self.obj.source_info.sector)
-            tpf = search_result.download(cutout_size=(self.obj.tpf.shape[1], self.obj.tpf.shape[2]))
+            try:
+                search_result = lk.search_tesscut(f'TIC {tic}', sector=self.obj.source_info.sector)
+                if len(search_result) == 0:
+                    raise ValueError("lightkurve.search_tesscut() returned no results.")
+                tpf = search_result.download(cutout_size=(self.obj.tpf.shape[1], self.obj.tpf.shape[2]))
+            except:
+                # If lightkurve.search_tesscut() returns no result or raise an error,
+                # utilize astroquery.mast.TesscutClass.download_cutouts() instead.
+                from astroquery.mast import Tesscut
+                # Download to the same path as lightkurve.search_tesscut().downlaod() does.
+                tesscut_path = os.path.join(os.path.expanduser('~'), '.lightkurve-cache/tesscut')
+                tpf_path_table = Tesscut.download_cutouts(objectname=f'TIC {tic}',
+                                                          size=(self.obj.tpf.shape[1], self.obj.tpf.shape[2]),
+                                                          sector=self.obj.source_info.sector,
+                                                          path=tesscut_path)
+                tpf = lk.read(tpf_path_table['Local Path'].data[0])
 
         # Get the positions of the Gaia sources
         c1 = SkyCoord(tpf.ra, tpf.dec, frame='icrs', unit='deg')

--- a/eleanor/visualize.py
+++ b/eleanor/visualize.py
@@ -354,9 +354,26 @@ class Visualize(object):
             return
 
 
-    def plot_gaia_overlay(self, tic=None, tpf=None, magnitude_limit=18):
-        """Check if the source is contaminated."""
+    def plot_gaia_overlay(self, tic=None, tpf=None, cadence=0, ax=None, magnitude_limit=18):
+        """
+        Check if the source is contaminated.
 
+        Parameters
+        ----------
+        tic : int, optional
+            The TIC ID of the source.
+        tpf : lightkurve.TargetPixelFile, optional
+            Target Pixel File object. If None, searches and downloads TPF from MAST.
+            Default is None.
+        cadence : int, optional
+            Index of the cadence in the TPF to plot.
+            Default is 0 (the first cadence).
+        ax : matplotlib.axes._subplots.AxesSubplot, optional
+            Axes to plot on.
+        magnitude_limit : float, optional
+            The Gaia G magnitude limit for the Gaia sources to be plotted.
+            Default is 18.
+        """
         if tic is None:
             tic = self.obj.source_info.tic
 
@@ -364,8 +381,13 @@ class Visualize(object):
             tpf = lk.search_tesscut(f'TIC {tic}')[0].download(cutout_size=(self.obj.tpf.shape[1],
                                                                            self.obj.tpf.shape[2]))
 
-        fig = tpf.plot(show_colorbar=False, title='TIC {0}'.format(tic))
-        fig = self._add_gaia_figure_elements(tpf, fig, magnitude_limit=magnitude_limit)
+        if ax is None:
+            ax = tpf[cadence].plot(show_colorbar=False, title=f'TIC {tic}')
+        else:
+            ax = tpf[cadence].plot(ax=ax, show_colorbar=False, title=f'TIC {tic}')
+
+        ax = self.add_gaia_figure_elements(fig_or_ax=ax, individual=False, tpf=tpf, magnitude_limit=magnitude_limit)
+        return ax
 
     def add_gaia_figure_elements(self, fig_or_ax, individual=True, tic=None, tpf=None, magnitude_limit=18):
         """

--- a/eleanor/visualize.py
+++ b/eleanor/visualize.py
@@ -66,7 +66,8 @@ class Visualize(object):
         ax : matplotlib.axes._subplots.AxesSubplot, optional
             Axes to plot on.
         """
-        if ax == None:
+        ax_given = ax
+        if ax is None:
             fig, ax = plt.subplots(nrows=1)
 
         if aperture is None:
@@ -85,7 +86,7 @@ class Visualize(object):
         ax.contour(Z, [0.05], colors=ap_color, linewidths=[ap_linewidth],
                     extent=[0-0.5, x[:-1].max()-0.5,0-0.5, y[:-1].max()-0.5])
 
-        if ax == None:
+        if ax_given is None:
             return fig
 
 

--- a/eleanor/visualize.py
+++ b/eleanor/visualize.py
@@ -48,7 +48,7 @@ class Visualize(object):
             self.dimensions = self.obj.dimensions
 
 
-    def aperture_contour(self, aperture=None, ap_color='w', ap_linewidth=4, ax=None, **kwargs):
+    def aperture_contour(self, aperture=None, cadence=0, ap_color='w', ap_linewidth=4, ax=None, **kwargs):
         """
         Overplots the countour of an aperture on a target pixel file.
         Contribution from Gijs Mulders.
@@ -58,6 +58,9 @@ class Visualize(object):
         aperture : np.2darray, optional
             A 2D mask the same size as the target pixel file. Default
             is the eleanor default aperture.
+        cadence : int, optional
+            Index of the cadence in the TPF to plot.
+            Default is 0 (the first cadence).
         ap_color : str, optional
             The color of the aperture contour. Takes a matplotlib color.
             Default is red.
@@ -73,7 +76,7 @@ class Visualize(object):
         if aperture is None:
             aperture = self.obj.aperture
 
-        ax.imshow(self.obj.tpf[0], origin='lower', **kwargs)
+        ax.imshow(self.obj.tpf[cadence], origin='lower', **kwargs)
 
         f = lambda x,y: aperture[int(y),int(x) ]
         g = np.vectorize(f)

--- a/eleanor/visualize.py
+++ b/eleanor/visualize.py
@@ -416,7 +416,16 @@ class Visualize(object):
         if len(result) == 0:
             raise no_targets_found_message
         radecs = np.vstack([result['RA_ICRS'], result['DE_ICRS']]).T
+
         coords = tpf.wcs.all_world2pix(radecs, 0)
+        # Correct the pixel coordinates when TPF is truncated to the border of the postcard and
+        # the star is not located in the center of the TPF
+        if ((self.obj.source_info.tc == False and individual) and
+                (self.obj.tpf_star_x != int(np.floor(self.obj.tpf.shape[1] / 2)) or
+                 self.obj.tpf_star_y != int(np.floor(self.obj.tpf.shape[2] / 2)))):
+            coords[:, 0] -= int(np.floor(self.obj.tpf.shape[1] / 2) + 1) - self.obj.tpf_star_x
+            coords[:, 1] -= int(np.floor(self.obj.tpf.shape[2] / 2) + 1) - self.obj.tpf_star_y
+
         try:
             year = ((tpf.time[0].jd - 2457206.375) * u.day).to(u.year)
         except:
@@ -430,7 +439,15 @@ class Visualize(object):
         sizes = 10000.0 / 2**(result['Gmag']/2)
 
         target = tpf.wcs.world_to_pixel(c1)
-        plt.scatter(target[0]+tpf.column, target[1]+tpf.row, s=50, zorder=1000, c='k', marker='x')
+        target_x = target[0]
+        target_y = target[1]
+        # Correct the pixel coordinates when TPF is truncated to the border of the postcard and
+        # the star is not located in the center of the TPF
+        if ((self.obj.source_info.tc == False and individual) and
+                (self.obj.tpf_star_x != int(np.floor(self.obj.tpf.shape[1] / 2)) or
+                 self.obj.tpf_star_y != int(np.floor(self.obj.tpf.shape[2] / 2)))):
+            target_x -= int(np.floor(self.obj.tpf.shape[1] / 2) + 1) - self.obj.tpf_star_x
+            target_y -= int(np.floor(self.obj.tpf.shape[2] / 2) + 1) - self.obj.tpf_star_y
 
         if isinstance(fig_or_ax, plt.Figure):
             ax = fig_or_ax.gca()


### PR DESCRIPTION
This PR fixed boundary calculations of `TargetData.get_tpf_from_postcard()`, enhanced the functionality and fixed some issues in the `Visualize()` class. 
The first commit fixed issue of getting incorrect TPF (and also aperture and background TPF) from postcard (like the figure shown below) when the source is near the edge of postcard or the TPF size is too big for the postcard by refactoring boundary calculations for postage stamp. 
<img width="302" alt="Incorrect TPF" src="https://github.com/user-attachments/assets/2af60b24-1a5f-4844-a784-bfc089997ae3" />
Incorrect TPF
<img width="184" alt="Incorrect Aperture" src="https://github.com/user-attachments/assets/174ad34a-3a5f-4a9c-b54e-83069e5ab6e6" />
Incorrect Aperture
<img width="186" alt="Incorrect Background TPF" src="https://github.com/user-attachments/assets/6fa7732d-dd3b-4407-85f4-0cce580a6780" />
Incorrect Background TPF