### PR TITLE
fixing issues with eleanor_path

### DIFF
--- a/eleanor/postcard.py
+++ b/eleanor/postcard.py
@@ -215,15 +215,10 @@ class Postcard_tesscut(object):
         (`x`, `y`) coordinates corresponding to the location of
         the postcard's (0,0) pixel on the FFI.
     """
-    def __init__(self, cutout, location=None, eleanorpath=None):
-
-        if eleanorpath is None:
-            self.eleanor_path = os.path.join(os.path.expanduser('~'), '.eleanor')
-        else:
-            self.eleanor_path = eleanorpath
+    def __init__(self, cutout, location=None):
 
         if location is None:
-            self.local_path = os.path.join(self.eleanor_path, 'tesscut')
+            self.local_path = os.path.join(os.path.expanduser('~'), '.eleanor/tesscut')
         else:
             self.local_path = location
 
@@ -336,7 +331,8 @@ class Postcard_tesscut(object):
     @property
     def quality(self):
         sector = self.header['SECTOR']
-        A = np.loadtxt(self.eleanor_path + '/metadata/s{0:04d}/quality_s{0:04d}.txt'.format(sector))
+        eleanorpath = os.path.join(os.path.expanduser('~'), '.eleanor')
+        A = np.loadtxt(eleanorpath + '/metadata/s{0:04d}/quality_s{0:04d}.txt'.format(sector))
         if sector == 65:
             if self.header['CAMERA'] == 4:
                 if self.header['CCD'] == 4:
@@ -350,7 +346,7 @@ class Postcard_tesscut(object):
                 f" for {source_id_str(self)}."
                 " Regenerate them."
             )
-            A = calc_quality(self.hdu, sector, eleanorpath=self.eleanor_path)
+            A = calc_quality(self.hdu, sector)
         return A
 
     @property
@@ -367,7 +363,8 @@ class Postcard_tesscut(object):
     @property
     def ffiindex(self):
         sector = self.header['SECTOR']
-        A = np.loadtxt(self.eleanor_path + '/metadata/s{0:04d}/cadences_s{0:04d}.txt'.format(sector))
+        eleanorpath = os.path.join(os.path.expanduser('~'), '.eleanor')
+        A = np.loadtxt(eleanorpath + '/metadata/s{0:04d}/cadences_s{0:04d}.txt'.format(sector))
         if sector == 65:
             if self.header['CAMERA'] == 4:
                 if self.header['CCD'] == 4:
@@ -393,7 +390,7 @@ def source_id_str(post_obj):
     return f"sector {h.get('SECTOR')}, camera {h.get('CAMERA')}, CCD {h.get('CCD')}"
 
 
-def calc_quality(ffi_hdu, sector, eleanorpath=None):
+def calc_quality(ffi_hdu, sector):
     """ Uses the quality flags in a 2-minute target to create quality flags
         for the given postcard.
     """
@@ -403,8 +400,7 @@ def calc_quality(ffi_hdu, sector, eleanorpath=None):
 
     ffi_time = ffi_hdu[1].data['TIME'] # - ffi_hdu[1].data['TIMECORR']
 
-    if eleanorpath is None:
-        eleanorpath = os.path.join(os.path.expanduser('~'), '.eleanor')
+    eleanorpath = os.path.join(os.path.expanduser('~'), '.eleanor')
     shortCad_fn = eleanorpath + '/metadata/s{0:04d}/target_s{0:04d}.fits'.format(sector)
 
     # Binary string for values which apply to the FFIs

--- a/eleanor/source.py
+++ b/eleanor/source.py
@@ -171,18 +171,15 @@ class Source(object):
         else:
             self.fn_dir  = fn_dir
 
-        #self.eleanorpath = os.path.join(os.path.expanduser('~'), '.eleanor')
+        self.eleanorpath = os.path.join(os.path.expanduser('~'), '.eleanor')
 
-        if metadata_path is None:
-            self.metadata_path = os.path.join(os.path.expanduser('~'), '.eleanor')
-        else:
-            self.metadata_path = metadata_path
+        self.metadata_path = metadata_path or self.eleanorpath
 
-        if not os.path.exists(self.metadata_path):
+        if not os.path.exists(self.eleanorpath):
             try:
-                os.mkdir(self.metadata_path)
+                os.mkdir(self.eleanorpath)
             except OSError:
-                self.metadata_path = os.path.dirname(__file__)
+                self.eleanorpath = os.path.dirname(__file__)
 
         if not os.path.exists(self.metadata_path + '/metadata'):
             os.mkdir(self.metadata_path + '/metadata')

--- a/eleanor/targetdata.py
+++ b/eleanor/targetdata.py
@@ -190,8 +190,7 @@ class TargetData(object):
                     self.post_obj = Postcard(source.postcard, source.postcard_bkg,
                                              source.postcard_path)
                 else:
-                    location_path = os.path.join(source.metadata_path, 'tesscut')
-                    self.post_obj = Postcard_tesscut(source.cutout, location=location_path, eleanorpath=source.metadata_path)
+                    self.post_obj = Postcard_tesscut(source.cutout)
 
                 ### print(f"DBGt __init__() - #.post_obj={self.post_obj.dimensions}, #.post_obj.quality={self.post_obj.quality.shape}")
                 self.ffiindex = self.post_obj.ffiindex

--- a/eleanor/update.py
+++ b/eleanor/update.py
@@ -15,6 +15,13 @@ from astropy.coordinates import SkyCoord
 from .assignments import assign_year, assign_target
 
 
+eleanorpath = os.path.join(os.path.expanduser('~'), '.eleanor')
+if not os.path.exists(eleanorpath):
+    try:
+        os.mkdir(eleanorpath)
+    except OSError:
+        eleanorpath = os.path.dirname(__file__)
+
 def hmsm_to_days(hour=0, min=0, sec=0, micro=0):
     days = sec + (micro / 1.e6)
     days = min + (days / 60.)
@@ -77,17 +84,15 @@ def update_all():
 class Update(object):
     def __init__(self, sector=None):
 
-        eleanor_metadata_path = os.path.join(os.path.expanduser('~'), '.eleanor')
-
         if sector is None:
             print('Please pass a sector into eleanor.Update().')
             return
 
-        if not os.path.exists(eleanor_metadata_path + '/metadata'):
-            os.mkdir(eleanor_metadata_path + '/metadata')
+        if not os.path.exists(eleanorpath + '/metadata'):
+            os.mkdir(eleanorpath + '/metadata')
 
         self.sector = sector
-        self.metadata_path = os.path.join(eleanor_metadata_path, 'metadata/s{0:04d}'.format(self.sector))
+        self.metadata_path = os.path.join(eleanorpath, 'metadata/s{0:04d}'.format(self.sector))
         lastfile = 'cbv_components_s{0:04d}_0004_0004.txt'.format(self.sector)
 
         # Checks to see if directory contains all necessary files first


### PR DESCRIPTION
in my earlier pr "metadata_path paramter for source is now used, setting where data is stored" (#288), I introduced a major bug that at the time caused a silent failure of the CBV creation, and now is seen in a warning raised. Essentially the source object attribute .eleanorpath was no longer created, and in one line was not edited to reflect that change, causing the issue. THis PR simply removes/undoes many of the breaking changes of that pr.